### PR TITLE
refactor: remove dotenvy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,17 +162,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenvy"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
 name = "falcon-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
- "dotenvy",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-dotenvy = "0.15"
 
 [profile.release]
 strip = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,6 @@ use config::Config;
 
 #[tokio::main]
 async fn main() {
-    // Load .env file if present (errors are silently ignored)
-    let _ = dotenvy::dotenv();
-
-    warn_if_env_file_is_world_readable();
-
     let cli = Cli::parse();
 
     let config = match build_config(&cli) {
@@ -39,22 +34,6 @@ async fn main() {
         Err(e) => {
             eprintln!("Error: {}", e);
             std::process::exit(1);
-        }
-    }
-}
-
-fn warn_if_env_file_is_world_readable() {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Ok(metadata) = std::fs::metadata(".env") {
-            let mode = metadata.permissions().mode();
-            if mode & 0o077 != 0 {
-                eprintln!(
-                    "Warning: .env file has permissions {:o}. Consider running: chmod 600 .env",
-                    mode & 0o777
-                );
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Remove `dotenvy` crate dependency and `.env` file loading logic
- Remove `.env` file permission warning function (`warn_if_env_file_is_world_readable`)
- Environment variables are set by the shell directly instead of loading from `.env` files at runtime

## Why

`.env` file loading at runtime is unnecessary for this CLI tool. Users should configure environment variables through their shell environment.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes

Generated with [Claude Code](https://claude.com/claude-code)