### PR TITLE
feat: add alert investigate subcommand and improve alert help

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Manage alerts (list, get, automated-lead)
+    /// Manage alerts
     Alert {
         #[command(subcommand)]
         action: commands::alerts::Action,
@@ -562,5 +562,14 @@ pub enum Command {
     ZeroTrust {
         #[command(subcommand)]
         action: commands::zero_trust_assessment::Action,
+    },
+
+    // ── Extended (multi-API) ──
+    // Commands below combine multiple Falcon API calls into a single operation.
+    // They are falcon-cli specific and do not map 1:1 to a Falcon API endpoint.
+    /// Investigate automated-lead alerts [multi-API]
+    AutomatedLead {
+        #[command(subcommand)]
+        action: commands::automated_lead::Action,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Manage alerts
+    /// Manage alerts (list, get, investigate)
     Alert {
         #[command(subcommand)]
         action: commands::alerts::Action,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Manage alerts (list, get, investigate)
+    /// Manage alerts (list, get, automated-lead)
     Alert {
         #[command(subcommand)]
         action: commands::alerts::Action,

--- a/src/commands/alerts.rs
+++ b/src/commands/alerts.rs
@@ -8,11 +8,23 @@ use crate::error::Result;
 pub enum Action {
     /// List alert IDs
     ///
+    /// Returns alert composite IDs matching the specified filter criteria.
+    /// Use these IDs with the `get` subcommand to retrieve full alert details.
+    ///
+    /// FQL filter examples:
+    ///   --filter "type:'automated-lead'"            Automated Lead alerts only
+    ///   --filter "aggregate_id:'<id>'"              Detections linked to a lead
+    ///   --filter "status:'new'"                     Alerts with status new
+    ///   --filter "status:'closed'"                  Alerts with status closed
+    ///   --filter "severity:>=60"                    Severity >= 60
+    ///   --filter "device.device_id:'<device_id>'"   Alerts for a specific device
+    ///   --filter "type:'automated-lead'+status:'new'"  Combine with + (AND)
+    ///
     /// Response fields:
-    ///   resources  - array of alert ID strings
+    ///   resources  - array of alert composite ID strings
     ///   errors     - array of error objects (if any)
     List {
-        /// FQL filter expression
+        /// FQL filter expression (e.g. "type:'automated-lead'", "aggregate_id:'<id>'")
         #[arg(long)]
         filter: Option<String>,
 
@@ -26,16 +38,23 @@ pub enum Action {
     },
     /// Get alert details by composite ID
     ///
+    /// Composite ID formats:
+    ///   automated-lead:  <cid>:automated-lead:<cid>:<lead_id>
+    ///   detection (ind): <cid>:ind:<device_id>:<process_id>-<pattern_id>-<offset>
+    ///
     /// Response fields:
-    ///   composite_id          - unique alert composite identifier
-    ///   status                - alert status
-    ///   severity              - alert severity
-    ///   tactic                - MITRE ATT&CK tactic
-    ///   technique             - MITRE ATT&CK technique
-    ///   created_timestamp     - alert creation timestamp
-    ///   updated_timestamp     - alert update timestamp
+    ///   composite_id      - unique alert composite identifier
+    ///   type              - alert type (e.g. "automated-lead")
+    ///   aggregate_id      - links lead and its detections (use with list --filter)
+    ///   status            - alert status
+    ///   severity          - alert severity
+    ///   tactic            - MITRE ATT&CK tactic
+    ///   technique         - MITRE ATT&CK technique
+    ///   device.device_id  - device identifier
+    ///   created_timestamp - alert creation timestamp
+    ///   updated_timestamp - alert update timestamp
     Get {
-        /// Alert composite ID(s)
+        /// Alert composite ID(s) (e.g. "<cid>:automated-lead:<cid>:<lead_id>")
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },

--- a/src/commands/alerts.rs
+++ b/src/commands/alerts.rs
@@ -2,7 +2,7 @@ use clap::Subcommand;
 
 use crate::client::FalconClient;
 use crate::commands::build_query_path;
-use crate::error::{FalconError, Result};
+use crate::error::Result;
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -58,24 +58,6 @@ pub enum Action {
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },
-    /// Get an automated-lead and its related detections in one step
-    ///
-    /// Retrieves the lead details, finds all related detections via
-    /// aggregate_id, and returns everything in a single JSON response.
-    ///
-    /// This automates the manual workflow:
-    ///   1. alert get --id <composite_id>
-    ///   2. Copy aggregate_id from the response
-    ///   3. alert list --filter "aggregate_id:'<aggregate_id>'"
-    ///   4. alert get --id <detection_id_1> <detection_id_2> ...
-    ///
-    /// Output format:
-    ///   { "lead": { ... }, "detections": [ ... ] }
-    AutomatedLead {
-        /// Automated-lead composite ID
-        #[arg(long, required = true)]
-        id: String,
-    },
 }
 
 pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json::Value> {
@@ -96,46 +78,6 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
         Action::Get { id } => {
             let body = serde_json::json!({ "composite_ids": id });
             client.post("/alerts/entities/alerts/v2", &body).await
-        }
-        Action::AutomatedLead { id } => {
-            // Step 1: Get lead details
-            let body = serde_json::json!({ "composite_ids": [&id] });
-            let lead_response = client.post("/alerts/entities/alerts/v2", &body).await?;
-
-            // Step 2: Extract aggregate_id
-            let aggregate_id = lead_response["resources"][0]["aggregate_id"]
-                .as_str()
-                .ok_or_else(|| {
-                    FalconError::Api("aggregate_id not found in alert response".to_string())
-                })?;
-
-            // Step 3: Find related detection IDs via aggregate_id
-            let filter = format!("aggregate_id:'{}'", aggregate_id);
-            let path = build_query_path("/alerts/queries/alerts/v2", Some(&filter), 100, None);
-            let list_response = client.get(&path).await?;
-
-            let detection_ids: Vec<String> = list_response["resources"]
-                .as_array()
-                .unwrap_or(&vec![])
-                .iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .filter(|did| *did != id)
-                .collect();
-
-            // Step 4: Get detection details
-            let detections = if detection_ids.is_empty() {
-                serde_json::json!([])
-            } else {
-                let det_body = serde_json::json!({ "composite_ids": detection_ids });
-                let det_response = client.post("/alerts/entities/alerts/v2", &det_body).await?;
-                det_response["resources"].clone()
-            };
-
-            // Step 5: Return combined result
-            Ok(serde_json::json!({
-                "lead": lead_response["resources"][0],
-                "detections": detections
-            }))
         }
     }
 }

--- a/src/commands/alerts.rs
+++ b/src/commands/alerts.rs
@@ -2,7 +2,7 @@ use clap::Subcommand;
 
 use crate::client::FalconClient;
 use crate::commands::build_query_path;
-use crate::error::Result;
+use crate::error::{FalconError, Result};
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -58,6 +58,24 @@ pub enum Action {
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },
+    /// Investigate a lead and its related detections in one step
+    ///
+    /// Retrieves the lead details, finds all related detections via
+    /// aggregate_id, and returns everything in a single JSON response.
+    ///
+    /// This automates the manual workflow:
+    ///   1. alert get --id <composite_id>
+    ///   2. Copy aggregate_id from the response
+    ///   3. alert list --filter "aggregate_id:'<aggregate_id>'"
+    ///   4. alert get --id <detection_id_1> <detection_id_2> ...
+    ///
+    /// Output format:
+    ///   { "lead": { ... }, "detections": [ ... ] }
+    Investigate {
+        /// Alert composite ID to investigate
+        #[arg(long, required = true)]
+        id: String,
+    },
 }
 
 pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json::Value> {
@@ -78,6 +96,46 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
         Action::Get { id } => {
             let body = serde_json::json!({ "composite_ids": id });
             client.post("/alerts/entities/alerts/v2", &body).await
+        }
+        Action::Investigate { id } => {
+            // Step 1: Get lead details
+            let body = serde_json::json!({ "composite_ids": [&id] });
+            let lead_response = client.post("/alerts/entities/alerts/v2", &body).await?;
+
+            // Step 2: Extract aggregate_id
+            let aggregate_id = lead_response["resources"][0]["aggregate_id"]
+                .as_str()
+                .ok_or_else(|| {
+                    FalconError::Api("aggregate_id not found in alert response".to_string())
+                })?;
+
+            // Step 3: Find related detection IDs via aggregate_id
+            let filter = format!("aggregate_id:'{}'", aggregate_id);
+            let path = build_query_path("/alerts/queries/alerts/v2", Some(&filter), 100, None);
+            let list_response = client.get(&path).await?;
+
+            let detection_ids: Vec<String> = list_response["resources"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter(|did| *did != id)
+                .collect();
+
+            // Step 4: Get detection details
+            let detections = if detection_ids.is_empty() {
+                serde_json::json!([])
+            } else {
+                let det_body = serde_json::json!({ "composite_ids": detection_ids });
+                let det_response = client.post("/alerts/entities/alerts/v2", &det_body).await?;
+                det_response["resources"].clone()
+            };
+
+            // Step 5: Return combined result
+            Ok(serde_json::json!({
+                "lead": lead_response["resources"][0],
+                "detections": detections
+            }))
         }
     }
 }

--- a/src/commands/alerts.rs
+++ b/src/commands/alerts.rs
@@ -58,7 +58,7 @@ pub enum Action {
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },
-    /// Investigate a lead and its related detections in one step
+    /// Get an automated-lead and its related detections in one step
     ///
     /// Retrieves the lead details, finds all related detections via
     /// aggregate_id, and returns everything in a single JSON response.
@@ -71,8 +71,8 @@ pub enum Action {
     ///
     /// Output format:
     ///   { "lead": { ... }, "detections": [ ... ] }
-    Investigate {
-        /// Alert composite ID to investigate
+    AutomatedLead {
+        /// Automated-lead composite ID
         #[arg(long, required = true)]
         id: String,
     },
@@ -97,7 +97,7 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
             let body = serde_json::json!({ "composite_ids": id });
             client.post("/alerts/entities/alerts/v2", &body).await
         }
-        Action::Investigate { id } => {
+        Action::AutomatedLead { id } => {
             // Step 1: Get lead details
             let body = serde_json::json!({ "composite_ids": [&id] });
             let lead_response = client.post("/alerts/entities/alerts/v2", &body).await?;

--- a/src/commands/automated_lead.rs
+++ b/src/commands/automated_lead.rs
@@ -1,0 +1,75 @@
+use clap::Subcommand;
+
+use crate::client::FalconClient;
+use crate::commands::build_query_path;
+use crate::error::{FalconError, Result};
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Get a lead and its related detections in one step
+    ///
+    /// This is a falcon-cli extended command that combines multiple API calls.
+    /// It does not map to a single Falcon API endpoint.
+    ///
+    /// Retrieves the lead details, finds all related detections via
+    /// aggregate_id, and returns everything in a single JSON response.
+    ///
+    /// This automates the manual workflow:
+    ///   1. alert get --id <composite_id>
+    ///   2. Copy aggregate_id from the response
+    ///   3. alert list --filter "aggregate_id:'<aggregate_id>'"
+    ///   4. alert get --id <detection_id_1> <detection_id_2> ...
+    ///
+    /// Output format:
+    ///   { "lead": { ... }, "detections": [ ... ] }
+    Get {
+        /// Automated-lead composite ID (e.g. "<cid>:automated-lead:<cid>:<lead_id>")
+        #[arg(long, required = true)]
+        id: String,
+    },
+}
+
+pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json::Value> {
+    match action {
+        Action::Get { id } => {
+            // Step 1: Get lead details
+            let body = serde_json::json!({ "composite_ids": [&id] });
+            let lead_response = client.post("/alerts/entities/alerts/v2", &body).await?;
+
+            // Step 2: Extract aggregate_id
+            let aggregate_id = lead_response["resources"][0]["aggregate_id"]
+                .as_str()
+                .ok_or_else(|| {
+                    FalconError::Api("aggregate_id not found in alert response".to_string())
+                })?;
+
+            // Step 3: Find related detection IDs via aggregate_id
+            let filter = format!("aggregate_id:'{}'", aggregate_id);
+            let path = build_query_path("/alerts/queries/alerts/v2", Some(&filter), 100, None);
+            let list_response = client.get(&path).await?;
+
+            let detection_ids: Vec<String> = list_response["resources"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .filter(|did| *did != id)
+                .collect();
+
+            // Step 4: Get detection details
+            let detections = if detection_ids.is_empty() {
+                serde_json::json!([])
+            } else {
+                let det_body = serde_json::json!({ "composite_ids": detection_ids });
+                let det_response = client.post("/alerts/entities/alerts/v2", &det_body).await?;
+                det_response["resources"].clone()
+            };
+
+            // Step 5: Return combined result
+            Ok(serde_json::json!({
+                "lead": lead_response["resources"][0],
+                "detections": detections
+            }))
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod alerts;
 pub mod api_integrations;
 pub mod aspm;
+pub mod automated_lead;
 pub mod cao_hunting;
 pub mod case_management;
 pub mod certificate_based_exclusions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,9 @@ async fn execute(
 ) -> error::Result<serde_json::Value> {
     match command {
         Command::Alert { action } => commands::alerts::execute(client, action).await,
+        Command::AutomatedLead { action } => {
+            commands::automated_lead::execute(client, action).await
+        }
         Command::ApiIntegration { action } => {
             commands::api_integrations::execute(client, action).await
         }


### PR DESCRIPTION
## Summary

- Add `alert investigate --id <composite_id>` subcommand that retrieves a lead and its related detections in one step
- Add FQL filter examples and composite ID format documentation to `alert list` and `alert get` help text

## Why

Investigating automated-lead alerts required a multi-step manual workflow:
1. `alert get --id <composite_id>` to get lead details
2. Manually extract `aggregate_id` from the response
3. `alert list --filter "aggregate_id:'<id>'"` to find related detection IDs
4. `alert get --id <det1> <det2> ...` to get each detection's details

Users needed to know undocumented FQL filter syntax (`aggregate_id`, `type`) and composite ID formats to perform this workflow. The `investigate` subcommand automates all four steps into a single command, and the help improvements make the manual workflow discoverable.

## Test plan

- [ ] `cargo build` / `cargo test` / `cargo fmt --check` / `cargo clippy -- -D warnings`
- [ ] `falcon-cli alert list --help` shows FQL filter examples
- [ ] `falcon-cli alert get --help` shows composite ID formats
- [ ] `falcon-cli alert investigate --help` shows usage and workflow description
- [ ] `falcon-cli alert investigate --id "<composite_id>"` returns combined lead + detections JSON

[comment by CC 🤖]