### PR TITLE
feat: default JSON output to compact format, add --pretty flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,6 +98,10 @@ pub struct Cli {
     #[arg(long, short, default_value = "json")]
     pub output: OutputFormat,
 
+    /// Pretty-print JSON output
+    #[arg(long)]
+    pub pretty: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ async fn main() {
 
     match result {
         Ok(value) => {
-            output::print_value(&value, &cli.output);
+            output::print_value(&value, &cli.output, cli.pretty);
         }
         Err(e) => {
             eprintln!("Error: {}", e);

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,18 +1,25 @@
 use crate::cli::OutputFormat;
 
-pub fn print_value(value: &serde_json::Value, format: &OutputFormat) {
+pub fn print_value(value: &serde_json::Value, format: &OutputFormat, pretty: bool) {
     match format {
-        OutputFormat::Json => match serde_json::to_string_pretty(value) {
-            Ok(s) => println!("{}", s),
-            Err(e) => eprintln!("Error formatting JSON: {}", e),
-        },
+        OutputFormat::Json => {
+            let result = if pretty {
+                serde_json::to_string_pretty(value)
+            } else {
+                serde_json::to_string(value)
+            };
+            match result {
+                Ok(s) => println!("{}", s),
+                Err(e) => eprintln!("Error formatting JSON: {}", e),
+            }
+        }
         OutputFormat::Table => {
-            print_table(value);
+            print_table(value, pretty);
         }
     }
 }
 
-fn print_table(value: &serde_json::Value) {
+fn print_table(value: &serde_json::Value, pretty: bool) {
     if let Some(resources) = value.get("resources").and_then(|r| r.as_array()) {
         if resources.is_empty() {
             println!("(no results)");
@@ -41,13 +48,25 @@ fn print_table(value: &serde_json::Value) {
                     print_row(&keys, &widths, item);
                 }
             }
-            _ => match serde_json::to_string_pretty(value) {
-                Ok(s) => println!("{}", s),
-                Err(e) => eprintln!("Error formatting JSON: {}", e),
-            },
+            _ => {
+                let result = if pretty {
+                    serde_json::to_string_pretty(value)
+                } else {
+                    serde_json::to_string(value)
+                };
+                match result {
+                    Ok(s) => println!("{}", s),
+                    Err(e) => eprintln!("Error formatting JSON: {}", e),
+                }
+            }
         }
     } else {
-        match serde_json::to_string_pretty(value) {
+        let result = if pretty {
+            serde_json::to_string_pretty(value)
+        } else {
+            serde_json::to_string(value)
+        };
+        match result {
             Ok(s) => println!("{}", s),
             Err(e) => eprintln!("Error formatting JSON: {}", e),
         }


### PR DESCRIPTION
## Summary
- JSON output to compact (single-line) format by default
- Add `--pretty` flag to opt into human-readable formatted output
- Apply the same behavior to table fallback paths in `output.rs`

## Why
CLI output is often piped into `jq` or other programs. Compact JSON is suitable as the default for machine consumption. Users who need readable output can use `--pretty`.

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] Verify default JSON output is compact
- [ ] Verify `--pretty` flag produces formatted JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)