### PR TITLE
feat: add alert update subcommand

### DIFF
--- a/src/commands/alerts.rs
+++ b/src/commands/alerts.rs
@@ -39,6 +39,26 @@ pub enum Action {
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },
+    /// Update alert status and add comments
+    ///
+    /// Uses PATCH /alerts/entities/alerts/v3 to update alerts.
+    ///
+    /// Examples:
+    ///   alert update --id <composite_id> --status closed --comment "false positive"
+    ///   alert update --id <id1> <id2> --status closed --comment "resolved"
+    Update {
+        /// Alert composite ID(s) to update
+        #[arg(long, required = true, num_args = 1..)]
+        id: Vec<String>,
+
+        /// New status (e.g. "new", "in_progress", "closed")
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Comment to add
+        #[arg(long)]
+        comment: Option<String>,
+    },
 }
 
 pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json::Value> {
@@ -59,6 +79,24 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
         Action::Get { id } => {
             let body = serde_json::json!({ "composite_ids": id });
             client.post("/alerts/entities/alerts/v2", &body).await
+        }
+        Action::Update {
+            id,
+            status,
+            comment,
+        } => {
+            let mut action_parameters = Vec::new();
+            if let Some(s) = status {
+                action_parameters.push(serde_json::json!({"name": "update_status", "value": s}));
+            }
+            if let Some(c) = comment {
+                action_parameters.push(serde_json::json!({"name": "append_comment", "value": c}));
+            }
+            let body = serde_json::json!({
+                "composite_ids": id,
+                "action_parameters": action_parameters,
+            });
+            client.patch("/alerts/entities/alerts/v3", &body).await
         }
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -187,6 +187,32 @@ fn test_all_subcommands_present() {
 }
 
 #[test]
+fn test_alert_help() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "alert", "--help"])
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("list"));
+    assert!(stdout.contains("get"));
+    assert!(stdout.contains("update"));
+}
+
+#[test]
+fn test_alert_update_help() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "alert", "update", "--help"])
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--id"));
+    assert!(stdout.contains("--status"));
+    assert!(stdout.contains("--comment"));
+}
+
+#[test]
 fn test_missing_credentials_error() {
     let output = Command::new("cargo")
         .args(["run", "--", "host", "list"])


### PR DESCRIPTION
## Summary
- Add `alert update` subcommand
- Uses PATCH `/alerts/entities/alerts/v3` to update alert status and append comments from the CLI
- Example: `falcon-cli alert update --id <composite_id> --status closed --comment "resolved"`

## Test plan
- [x] `cargo build` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Verified by closing an automated-lead alert in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)