### PR TITLE
fix: auto-discover agent socket path when FALCON_AGENT_SOCKET is unset

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,7 +18,13 @@ pub fn resolve_socket_path(explicit: Option<&str>) -> PathBuf {
         return PathBuf::from(p);
     }
 
-    // Fallback for agent status/stop without FALCON_AGENT_SOCKET set.
+    // Fallback: find the first existing socket in the socket directory.
+    let sockets = list_agent_sockets();
+    if sockets.len() == 1 {
+        return sockets.into_iter().next().unwrap();
+    }
+
+    // Multiple or no sockets: fall back to default name.
     resolve_socket_dir().join("falcon.sock")
 }
 


### PR DESCRIPTION
## What

Fix `falcon-cli agent status` to auto-discover the running agent's socket when `FALCON_AGENT_SOCKET` is not set.

## Why

`agent start` generates a PID-based socket path (`falcon-<PID>.sock`), but `resolve_socket_path()` fell back to a static `falcon.sock`. This mismatch caused `agent status` to always report the agent as not running when invoked from a shell without the environment variable (e.g., a different terminal session).

## How

Use `list_agent_sockets()` in the fallback path of `resolve_socket_path()`. When exactly one socket exists in the socket directory, return it directly. When zero or multiple sockets exist, keep the existing fallback behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)