### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## What

v0.2.1 をリリースするためのバージョンバンプです。

## Why

v0.2.0 以降に取り込まれたバグフィックス（`FALCON_AGENT_SOCKET` 未設定時のソケットパス自動検出）をリリースします。

## Changes

- `Cargo.toml` のバージョンを `0.2.0` → `0.2.1` に更新

## Included since v0.2.0

- fix: auto-discover agent socket path when FALCON_AGENT_SOCKET is unset (#10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)