### PR TITLE
fix: prevent agent start from stealing existing agent's socket

### DIFF
--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -71,9 +71,11 @@ pub fn start(
         }
     }
 
-    // Remove stale socket file.
+    // Remove stale socket file (same PID reuse after restart).
     match std::fs::remove_file(socket_path) {
-        Ok(_) => {}
+        Ok(_) => {
+            eprintln!("agent: removed stale socket {}", socket_path.display());
+        }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
             return Err(crate::error::FalconError::Config(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,10 @@ fn handle_agent_start(cli: &Cli, socket: Option<&str>, config: Option<&str>, for
     let falcon = client::FalconClient::new(auth, config_obj.base_url.clone());
     let falcon = Arc::new(falcon);
 
-    let socket_path = agent::resolve_socket_path(socket);
+    let socket_path = match socket {
+        Some(p) => std::path::PathBuf::from(p),
+        None => agent::generate_socket_path(),
+    };
     let config_path = config.map(std::path::PathBuf::from);
 
     if let Err(e) = agent::server::start(falcon, &socket_path, config_path.as_deref(), foreground) {


### PR DESCRIPTION
## Summary

- `agent start` was calling `resolve_socket_path()` (client-side path resolver) instead of `generate_socket_path()`, causing a new agent to delete and take over an existing agent's socket file
- The original agent process remained alive but unreachable (socket fd open, file deleted from filesystem)
- Added log output when a stale socket is removed for diagnostics

## Root Cause

`resolve_socket_path(None)` lists existing sockets and returns the first match when exactly one exists. The new agent then deletes it as "stale" at `server.rs:75`, binds to the same path, and when it shuts down (e.g., session leader exits), cleanup removes the socket again — leaving the original agent orphaned.

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] Start agent A, then start agent B without `--socket` — both should have unique socket files
- [ ] Verify agent A's socket is not deleted by agent B's startup

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)