### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary

- Bump version from 0.2.2 to 0.3.0

### Changes since v0.2.2

- feat: add tags and assignment options to alert update (#17)
- fix: prevent agent start from stealing existing agent's socket (#19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)