### PR TITLE
feat: add agent --shared mode for cross-terminal session sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,14 @@ cargo clippy -- -D warnings
 - Watchdog monitors terminal session liveness (`getsid`) and 8-hour idle timeout
 - `fork()` must happen before tokio runtime creation (see `main.rs`)
 
+### Shared Mode
+
+- `falcon-cli agent start --shared` writes session info to `~/.local/share/falcon-cli/session.json`
+- No `eval` needed; any terminal can auto-detect the agent via session file
+- Session leader monitoring is disabled; idle timeout (8h) still applies
+- `--no-agent` flag forces direct API mode, skipping agent auto-detection
+- Priority: `--no-agent` > `FALCON_AGENT_TOKEN` env > session.json > direct mode
+
 ## Code Quality
 
 - `cargo fmt --check` and `cargo clippy -- -D warnings` must pass

--- a/docs/adr/0003-agent-shared-mode.md
+++ b/docs/adr/0003-agent-shared-mode.md
@@ -1,0 +1,123 @@
+# ADR-0003: Agent shared モードによる複数ターミナルからの利用
+
+## ステータス
+
+承認済み（実装完了）
+
+## 日付
+
+2026-03-18
+
+## コンテキスト
+
+falcon-cli の agent は ssh-agent をモデルにしたセキュリティデザインを採用しています（ADR-0001 参照）。`eval "$(falcon-cli agent start)"` でシェルに環境変数（`FALCON_AGENT_SOCKET`, `FALCON_AGENT_TOKEN`）を設定し、そのターミナルセッション内でのみ agent 経由のコマンド実行を可能にします。
+
+この設計は単一ターミナルでの利用では堅牢ですが、以下の運用上の不便が生じています。
+
+### 問題: 複数ターミナルからの利用ができない
+
+- agent が返す環境変数は `eval` を実行したシェルにしか存在しません
+- 別のターミナルから同じ agent を利用するには、ソケットパスとトークンを手動でコピーする必要があります
+- tmux の複数ペイン、複数の iTerm2 タブなど、日常的なワークフローで不便です
+
+### 既存の仕組み
+
+- `resolve_socket_path()` はソケットディレクトリ内の `.sock` ファイルを探索する機能を持っています
+- しかし、トークンの自動解決手段がないため、ソケットが見つかっても認証できません
+
+## 決定
+
+### `--shared` オプションの導入
+
+`agent start` に `--shared` オプションを追加し、eval モードと排他的に使い分けます。
+
+#### eval モード（現行）
+
+```bash
+eval "$(falcon-cli agent start)"
+```
+
+- 環境変数を stdout に出力します
+- session.json は作成しません
+- watchdog がセッションリーダーの生存を監視します
+- ターミナルを閉じると agent が停止します
+
+#### shared モード（新規）
+
+```bash
+falcon-cli agent start --shared
+```
+
+- stdout に eval 用の変数を出力しません
+- `~/.local/share/falcon-cli/session.json` にソケットパスとトークンを書き出します
+- watchdog のセッションリーダー監視を無効化します（アイドルタイムアウトは維持）
+- 別のターミナルから `falcon-cli alert list` 等を実行すると、session.json から自動検出して agent 経由で実行します
+
+### session.json の仕様
+
+保存先: `$XDG_DATA_HOME/falcon-cli/session.json` (デフォルト: `~/.local/share/falcon-cli/session.json`)
+
+```json
+{
+  "socket_path": "/tmp/falcon-cli-501/falcon-12345.sock",
+  "token": "abcdef0123456789...",
+  "pid": 12345,
+  "started_at": "2026-03-18T10:00:00Z"
+}
+```
+
+- ファイルパーミッション: 0600
+- 親ディレクトリのパーミッション: 0700
+
+### コマンド実行時の優先順位
+
+```
+1. --no-agent フラグ           → direct mode を強制
+2. FALCON_AGENT_TOKEN 環境変数  → eval モードの agent 経由
+3. session.json                → shared モードの agent 経由
+4. FALCON_CLIENT_ID 環境変数    → direct mode
+```
+
+環境変数による明示指定は session.json より常に優先します。
+
+### agent stop の動作
+
+- eval モード/shared モード共通で、ソケット/PID ファイルから agent を特定して停止します
+- shared モードの agent 停止時は session.json も削除します
+- watchdog によるアイドルタイムアウト停止時も session.json を削除します
+- `agent stop --all` は全モードの agent を停止し、session.json も削除します
+
+### --no-agent フラグ
+
+session.json が存在しても agent 経由を抑制し、direct mode でコマンドを実行します。
+
+```bash
+falcon-cli --no-agent alert list --filter "status:'new'"
+```
+
+## 影響範囲
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `src/cli.rs` | `AgentAction::Start` に `--shared` フラグを追加。`Cli` に `--no-agent` フラグを追加 |
+| `src/agent/mod.rs` | `session_file_path()`, `write_session()`, `read_session()`, `remove_session()` を追加 |
+| `src/agent/server.rs` | shared モード時の session.json 書き出し・削除。watchdog のセッションリーダー監視の条件分岐 |
+| `src/main.rs` | `async_main()` で session.json フォールバックロジックを追加 |
+
+## セキュリティに関する考慮事項
+
+### リスク
+
+- session.json にトークンがディスクに保存されます（eval モードではメモリのみ）
+- session.json にアクセスできるプロセスは agent に接続できます
+
+### 緩和策
+
+- session.json のパーミッションは 0600 で、同一ユーザーのみ読み取り可能です
+- 既存の UID 検証・ピアプロセス検証（コード署名）は引き続き適用されます
+- agent 停止時・アイドルタイムアウト時に session.json を確実に削除します
+- eval モードを選択すれば、従来通りディスクにトークンを書き出しません
+
+### トレードオフ
+
+利便性（複数ターミナル共有）とセキュリティ（トークンのディスク保存）のトレードオフを、ユーザーが `--shared` フラグで明示的に選択します。デフォルトの動作は変更しません。

--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -72,6 +72,9 @@ pub fn stop(socket_path: &Path) -> Result<()> {
         }
     }
 
+    // Clean up session file if it references this agent.
+    cleanup_session_file(socket_path);
+
     eprintln!("sent SIGTERM to agent (PID {})", pid);
     Ok(())
 }
@@ -102,8 +105,20 @@ pub fn stop_all() -> Result<()> {
             sockets.len()
         )))
     } else {
+        // Clean up session file when stopping all agents.
+        crate::agent::session::remove_session();
         eprintln!("stopped {} agent(s)", sockets.len());
         Ok(())
+    }
+}
+
+/// Remove session file if it references the given socket path.
+fn cleanup_session_file(socket_path: &Path) {
+    if let Some(session) = crate::agent::session::read_session() {
+        if session.socket_path == socket_path.display().to_string() {
+            crate::agent::session::remove_session();
+            eprintln!("removed session file");
+        }
     }
 }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@ pub mod peer_verify;
 pub mod protocol;
 pub mod security;
 pub mod server;
+pub mod session;
 
 use std::path::PathBuf;
 use uuid::Uuid;

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -31,6 +31,7 @@ pub fn start(
     socket_path: &Path,
     config_path: Option<&Path>,
     foreground: bool,
+    shared: bool,
 ) -> crate::error::Result<()> {
     // Load security config.
     let security_config = match config_path {
@@ -104,6 +105,7 @@ pub fn start(
             session_token,
             true,
             session_leader_pid,
+            shared,
         ))
     } else {
         // Fork into the background (ssh-agent style).
@@ -113,6 +115,7 @@ pub fn start(
             whitelist,
             rate_limiter,
             session_token,
+            shared,
         )
     }
 }
@@ -126,6 +129,7 @@ fn fork_into_background(
     whitelist: Arc<CommandWhitelist>,
     rate_limiter: Arc<RateLimiter>,
     session_token: String,
+    shared: bool,
 ) -> crate::error::Result<()> {
     // Record the session leader PID before fork. Using getsid(0) instead of
     // getppid() so the watchdog monitors the terminal session leader (login
@@ -165,6 +169,7 @@ fn fork_into_background(
                 session_token,
                 false,
                 session_leader_pid,
+                shared,
             ))
         }
         child_pid => {
@@ -174,16 +179,27 @@ fn fork_into_background(
                 .parent()
                 .unwrap_or(Path::new("/tmp"))
                 .join(format!("falcon-{}.sock", child_pid));
-            println!(
-                "FALCON_AGENT_SOCKET={}; export FALCON_AGENT_SOCKET;",
-                actual_socket_path.display()
-            );
-            println!(
-                "FALCON_AGENT_TOKEN={}; export FALCON_AGENT_TOKEN;",
-                session_token
-            );
-            println!("FALCON_AGENT_PID={}; export FALCON_AGENT_PID;", child_pid);
-            println!("echo agent started, pid {};", child_pid);
+
+            if shared {
+                // Shared mode: no eval output. Session file is written by the child.
+                eprintln!("agent started in shared mode, pid {}", child_pid);
+                eprintln!(
+                    "session file: {}",
+                    crate::agent::session::session_file_path().display()
+                );
+            } else {
+                // Eval mode: output shell variables for eval.
+                println!(
+                    "FALCON_AGENT_SOCKET={}; export FALCON_AGENT_SOCKET;",
+                    actual_socket_path.display()
+                );
+                println!(
+                    "FALCON_AGENT_TOKEN={}; export FALCON_AGENT_TOKEN;",
+                    session_token
+                );
+                println!("FALCON_AGENT_PID={}; export FALCON_AGENT_PID;", child_pid);
+                println!("echo agent started, pid {};", child_pid);
+            }
             Ok(())
         }
     }
@@ -224,6 +240,7 @@ fn redirect_stdio(socket_path: &Path) {
 }
 
 /// Run the agent server (binds socket, accepts connections, handles shutdown).
+#[allow(clippy::too_many_arguments)]
 async fn run_agent(
     falcon_client: Arc<crate::client::FalconClient>,
     socket_path: &Path,
@@ -232,6 +249,7 @@ async fn run_agent(
     session_token: String,
     print_env: bool,
     session_leader_pid: libc::pid_t,
+    shared: bool,
 ) -> crate::error::Result<()> {
     // Bind the Unix listener.
     let listener = UnixListener::bind(socket_path).map_err(|e| {
@@ -272,6 +290,24 @@ async fn run_agent(
         session_token.clone(),
     ));
 
+    if shared {
+        // Shared mode: write session file for cross-terminal auto-detection.
+        let session_info = crate::agent::session::SessionInfo {
+            socket_path: socket_path.display().to_string(),
+            token: session_token.clone(),
+            pid: std::process::id(),
+            started_at: chrono::Utc::now(),
+        };
+        if let Err(e) = crate::agent::session::write_session(&session_info) {
+            eprintln!("agent: failed to write session file: {}", e);
+        } else {
+            eprintln!(
+                "agent: session file written to {}",
+                crate::agent::session::session_file_path().display()
+            );
+        }
+    }
+
     if print_env {
         // Foreground mode: output shell variables to stdout.
         println!(
@@ -287,26 +323,47 @@ async fn run_agent(
 
     eprintln!("agent: listening on {}", socket_path.display());
     eprintln!("agent: PID {}", std::process::id());
-    eprintln!("agent: session leader PID {}", session_leader_pid);
+    if shared {
+        eprintln!("agent: shared mode (session leader monitoring disabled)");
+    } else {
+        eprintln!("agent: session leader PID {}", session_leader_pid);
+    }
 
     // Accept loop with graceful shutdown on SIGTERM/SIGINT,
     // parent process exit detection, and idle timeout.
     let socket_path_owned = socket_path.to_owned();
     let pid_path_owned = pid_path.clone();
 
-    tokio::select! {
-        _ = accept_loop(&listener, handler, last_activity.clone()) => {}
-        _ = shutdown_signal() => {
-            eprintln!("agent: shutting down (signal)");
+    if shared {
+        // Shared mode: no session leader monitoring, idle timeout only.
+        tokio::select! {
+            _ = accept_loop(&listener, handler, last_activity.clone()) => {}
+            _ = shutdown_signal() => {
+                eprintln!("agent: shutting down (signal)");
+            }
+            reason = watchdog_idle_only(last_activity) => {
+                eprintln!("agent: shutting down ({})", reason);
+            }
         }
-        reason = watchdog(session_leader_pid, last_activity) => {
-            eprintln!("agent: shutting down ({})", reason);
+    } else {
+        tokio::select! {
+            _ = accept_loop(&listener, handler, last_activity.clone()) => {}
+            _ = shutdown_signal() => {
+                eprintln!("agent: shutting down (signal)");
+            }
+            reason = watchdog(session_leader_pid, last_activity) => {
+                eprintln!("agent: shutting down ({})", reason);
+            }
         }
     }
 
     // Cleanup.
     let _ = std::fs::remove_file(&socket_path_owned);
     let _ = std::fs::remove_file(&pid_path_owned);
+    if shared {
+        crate::agent::session::remove_session();
+        eprintln!("agent: session file removed");
+    }
     eprintln!("agent: stopped");
 
     Ok(())
@@ -470,6 +527,22 @@ async fn watchdog(session_leader_pid: libc::pid_t, last_activity: Arc<AtomicU64>
         }
 
         // Check idle timeout.
+        let last = last_activity.load(Ordering::Relaxed);
+        let now = epoch_secs();
+        if now.saturating_sub(last) >= IDLE_TIMEOUT_SECS {
+            return "idle timeout";
+        }
+    }
+}
+
+/// Watchdog task for shared mode: idle timeout only, no session leader monitoring.
+async fn watchdog_idle_only(last_activity: Arc<AtomicU64>) -> &'static str {
+    let mut interval =
+        tokio::time::interval(std::time::Duration::from_secs(WATCHDOG_INTERVAL_SECS));
+
+    loop {
+        interval.tick().await;
+
         let last = last_activity.load(Ordering::Relaxed);
         let now = epoch_secs();
         if now.saturating_sub(last) >= IDLE_TIMEOUT_SECS {

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -1,0 +1,114 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Session information persisted to disk for shared mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub socket_path: String,
+    pub token: String,
+    pub pid: u32,
+    pub started_at: DateTime<Utc>,
+}
+
+/// Resolve the session file path.
+/// Uses `$XDG_DATA_HOME/falcon-cli/session.json` (default: `~/.local/share/falcon-cli/session.json`).
+pub fn session_file_path() -> PathBuf {
+    if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
+        return PathBuf::from(data_home)
+            .join("falcon-cli")
+            .join("session.json");
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        return PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("falcon-cli")
+            .join("session.json");
+    }
+    PathBuf::from("/tmp/falcon-cli-session.json")
+}
+
+/// Write session info to disk with restricted permissions (0600).
+pub fn write_session(info: &SessionInfo) -> std::io::Result<()> {
+    let path = session_file_path();
+
+    // Ensure parent directory exists with 0700 permissions.
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+        }
+    }
+
+    let json = serde_json::to_string_pretty(info).map_err(std::io::Error::other)?;
+    std::fs::write(&path, json)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+/// Read session info from disk. Returns None if the file does not exist or is invalid.
+pub fn read_session() -> Option<SessionInfo> {
+    let path = session_file_path();
+    let content = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Remove the session file from disk.
+pub fn remove_session() {
+    let path = session_file_path();
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Check if the agent referenced by session info is still reachable (socket exists).
+pub fn is_session_alive(info: &SessionInfo) -> bool {
+    Path::new(&info.socket_path).exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_roundtrip() {
+        let info = SessionInfo {
+            socket_path: "/tmp/falcon-cli-501/falcon-12345.sock".to_string(),
+            token: "abcdef0123456789".to_string(),
+            pid: 12345,
+            started_at: Utc::now(),
+        };
+
+        let json = serde_json::to_string_pretty(&info).unwrap();
+        let loaded: SessionInfo = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(loaded.socket_path, info.socket_path);
+        assert_eq!(loaded.token, info.token);
+        assert_eq!(loaded.pid, info.pid);
+    }
+
+    #[test]
+    fn test_session_file_path_default() {
+        let path = session_file_path();
+        assert_eq!(path.file_name().unwrap(), "session.json");
+        assert!(path.to_string_lossy().contains("falcon-cli"));
+    }
+
+    #[test]
+    fn test_is_session_alive_nonexistent() {
+        let info = SessionInfo {
+            socket_path: "/tmp/falcon-cli-nonexistent-test.sock".to_string(),
+            token: "test".to_string(),
+            pid: 99999,
+            started_at: Utc::now(),
+        };
+        assert!(!is_session_alive(&info));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,6 +114,10 @@ pub struct Cli {
     #[arg(long, env = "FALCON_AGENT_TOKEN", hide_env = true, hide = true)]
     pub token: Option<String>,
 
+    /// Skip agent auto-detection and use direct API mode
+    #[arg(long)]
+    pub no_agent: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -812,6 +816,9 @@ pub enum AgentAction {
         /// Run in the foreground (do not fork into background)
         #[arg(long)]
         foreground: bool,
+        /// Share the agent across terminals via session file (no eval needed)
+        #[arg(long)]
+        shared: bool,
     },
     /// Stop the running agent
     Stop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,17 @@ fn main() {
                 socket,
                 config,
                 foreground,
+                shared,
             },
     } = &cli.command
     {
-        handle_agent_start(&cli, socket.as_deref(), config.as_deref(), *foreground);
+        handle_agent_start(
+            &cli,
+            socket.as_deref(),
+            config.as_deref(),
+            *foreground,
+            *shared,
+        );
         return;
     }
 
@@ -45,9 +52,19 @@ async fn async_main(cli: Cli) {
     }
 
     // If FALCON_AGENT_TOKEN is set, route through the agent automatically.
-    if cli.token.is_some() {
+    if !cli.no_agent && cli.token.is_some() {
         handle_agent_client(&cli).await;
         return;
+    }
+
+    // If no explicit token but a session file exists, use it for auto-detection.
+    if !cli.no_agent && cli.token.is_none() {
+        if let Some(session) = agent::session::read_session() {
+            if agent::session::is_session_alive(&session) {
+                handle_agent_client_from_session(&cli, session).await;
+                return;
+            }
+        }
     }
 
     // Handle shell completion generation.
@@ -105,7 +122,13 @@ fn build_config(cli: &Cli) -> error::Result<Config> {
 
 /// Handle `agent start` before tokio runtime is created.
 /// This allows fork() to run in a single-threaded process.
-fn handle_agent_start(cli: &Cli, socket: Option<&str>, config: Option<&str>, foreground: bool) {
+fn handle_agent_start(
+    cli: &Cli,
+    socket: Option<&str>,
+    config: Option<&str>,
+    foreground: bool,
+    shared: bool,
+) {
     let config_obj = match build_config(cli) {
         Ok(c) => c,
         Err(e) => {
@@ -124,7 +147,13 @@ fn handle_agent_start(cli: &Cli, socket: Option<&str>, config: Option<&str>, for
     };
     let config_path = config.map(std::path::PathBuf::from);
 
-    if let Err(e) = agent::server::start(falcon, &socket_path, config_path.as_deref(), foreground) {
+    if let Err(e) = agent::server::start(
+        falcon,
+        &socket_path,
+        config_path.as_deref(),
+        foreground,
+        shared,
+    ) {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }
@@ -190,6 +219,32 @@ async fn handle_agent_client(cli: &Cli) {
     }
 }
 
+async fn handle_agent_client_from_session(cli: &Cli, session: agent::session::SessionInfo) {
+    let socket_path = std::path::PathBuf::from(&session.socket_path);
+    let token = session.token;
+
+    let (command, action, args) = match extract_command_args(&cli.command) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let result = agent::client::send_command(&socket_path, token, command, action, args).await;
+
+    match result {
+        Ok(value) => {
+            output::print_value(&value, &cli.output, cli.pretty);
+        }
+        Err(e) => {
+            eprintln!("Error (via agent at {}): {}", socket_path.display(), e);
+            eprintln!("hint: is the agent running? check with: falcon-cli agent status");
+            std::process::exit(1);
+        }
+    }
+}
+
 /// Extract command name, action name, and arguments from the parsed Command enum.
 /// This reconstructs what the agent needs to dispatch the command.
 fn extract_command_args(
@@ -209,7 +264,7 @@ fn extract_command_args(
                    // Skip global flags.
     while i < raw_args.len() {
         let arg = &raw_args[i];
-        if arg == "--pretty" {
+        if arg == "--pretty" || arg == "--no-agent" {
             i += 1;
             continue;
         }


### PR DESCRIPTION
## What

Enable sharing a single falcon-cli agent across multiple terminal sessions without requiring `eval` in each shell.

## Why

The current ssh-agent model requires `eval "$(falcon-cli agent start)"` to inject environment variables into each terminal. This makes it impossible to use the agent from other terminals (tmux panes, iTerm2 tabs, etc.) without manually copying socket paths and tokens. For daily workflows involving multiple terminals, this is a significant friction point.

## How

Introduce `--shared` as an exclusive alternative to the eval-based mode:

| Mode | Start command | Token management | Session leader monitoring |
|------|--------------|-----------------|--------------------------|
| eval (existing) | `eval "$(falcon-cli agent start)"` | Environment variables | Enabled |
| shared (new) | `falcon-cli agent start --shared` | `~/.local/share/falcon-cli/session.json` | Disabled (idle timeout only) |

### Priority order for agent detection:
1. `--no-agent` flag → direct mode
2. `FALCON_AGENT_TOKEN` env → eval mode agent
3. `session.json` → shared mode agent
4. `FALCON_CLIENT_ID` env → direct mode

### Commits

1. **ADR-0003**: Design document for shared mode
2. **session.json infrastructure**: `SessionInfo` struct, read/write/remove with 0600 permissions, `--shared` and `--no-agent` CLI flags
3. **Integration**: Server writes session.json in shared mode, client auto-detects via session.json, cleanup on stop/timeout

## Test plan

- [x] `cargo test` — 15 unit + 9 integration tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] Manual test: `op run -- falcon-cli agent start --shared` + `falcon-cli alert list` from another context (no eval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)