### PR TITLE
feat: add --shared flag to agent status command

### DIFF
--- a/src/agent/client.rs
+++ b/src/agent/client.rs
@@ -49,6 +49,35 @@ pub async fn status(socket_path: &Path) -> AgentStatus {
         pid,
         socket_path: socket_path.display().to_string(),
         uptime_seconds: None,
+        shared: false,
+        session_file: None,
+    }
+}
+
+/// Check the status of the shared agent via session.json.
+pub async fn status_shared() -> AgentStatus {
+    let session_path = crate::agent::session::session_file_path();
+    match crate::agent::session::read_session() {
+        Some(session) => {
+            let socket_path = std::path::PathBuf::from(&session.socket_path);
+            let running = check_running(&socket_path).await;
+            AgentStatus {
+                running,
+                pid: Some(session.pid),
+                socket_path: session.socket_path,
+                uptime_seconds: None,
+                shared: true,
+                session_file: Some(session_path.display().to_string()),
+            }
+        }
+        None => AgentStatus {
+            running: false,
+            pid: None,
+            socket_path: String::new(),
+            uptime_seconds: None,
+            shared: true,
+            session_file: Some(session_path.display().to_string()),
+        },
     }
 }
 

--- a/src/agent/protocol.rs
+++ b/src/agent/protocol.rs
@@ -91,6 +91,10 @@ pub struct AgentStatus {
     pub pid: Option<u32>,
     pub socket_path: String,
     pub uptime_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub shared: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_file: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -834,5 +834,8 @@ pub enum AgentAction {
         /// Path to the Unix domain socket
         #[arg(long)]
         socket: Option<String>,
+        /// Show status from shared session file instead of socket
+        #[arg(long)]
+        shared: bool,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,9 +180,13 @@ async fn handle_agent_command(action: &AgentAction, _cli: &Cli) {
                 }
             }
         }
-        AgentAction::Status { socket } => {
-            let socket_path = agent::resolve_socket_path(socket.as_deref());
-            let status = agent::client::status(&socket_path).await;
+        AgentAction::Status { socket, shared } => {
+            let status = if *shared {
+                agent::client::status_shared().await
+            } else {
+                let socket_path = agent::resolve_socket_path(socket.as_deref());
+                agent::client::status(&socket_path).await
+            };
             let json = serde_json::to_string_pretty(&status)
                 .unwrap_or_else(|e| format!("{{\"error\": \"{}\"}}", e));
             println!("{}", json);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -215,9 +215,10 @@ fn test_alert_update_help() {
 #[test]
 fn test_missing_credentials_error() {
     let output = Command::new("cargo")
-        .args(["run", "--", "host", "list"])
+        .args(["run", "--", "--no-agent", "host", "list"])
         .env_remove("FALCON_CLIENT_ID")
         .env_remove("FALCON_CLIENT_SECRET")
+        .env_remove("FALCON_AGENT_TOKEN")
         .output()
         .expect("failed to execute");
 


### PR DESCRIPTION
## Summary

`falcon-cli agent status --shared` で shared mode の agent ステータスを確認できるようにします。

- session.json を読み取り、shared agent の稼働状態・PID・socket パス・session ファイルパスを JSON で返します
- shared agent が存在しない場合も `running: false` で応答します

## Why

`falcon-cli agent start --shared` で起動した shared agent のステータスを確認する手段がなく、`agent status` は socket パスベースの検索のみに対応していました。shared mode では session.json にセッション情報を永続化しているため、そこから読み取る `--shared` フラグを追加します。

## Changes

- `cli.rs`: `AgentAction::Status` に `--shared` フラグを追加
- `client.rs`: `status_shared()` 関数を追加（session.json 読み取り）
- `protocol.rs`: `AgentStatus` に `shared`/`session_file` フィールドを追加
- `main.rs`: `--shared` フラグでディスパッチを分岐
- `cli_test.rs`: session.json 存在時のテスト失敗を修正

## Test plan

- [x] `cargo test` 全テスト通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過
- [x] `falcon-cli agent status --shared` で shared agent のステータスが JSON で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)