### PR TITLE
feat: separate session file for debug builds (session.debug.json)

### DIFF
--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -11,22 +11,31 @@ pub struct SessionInfo {
     pub started_at: DateTime<Utc>,
 }
 
+/// Return the session file name based on build profile.
+/// Debug builds use `session.debug.json` to avoid conflicts with release builds.
+fn session_file_name() -> &'static str {
+    if cfg!(debug_assertions) {
+        "session.debug.json"
+    } else {
+        "session.json"
+    }
+}
+
 /// Resolve the session file path.
-/// Uses `$XDG_DATA_HOME/falcon-cli/session.json` (default: `~/.local/share/falcon-cli/session.json`).
+/// Uses `$XDG_DATA_HOME/falcon-cli/<session_file>` (default: `~/.local/share/falcon-cli/<session_file>`).
 pub fn session_file_path() -> PathBuf {
+    let file_name = session_file_name();
     if let Ok(data_home) = std::env::var("XDG_DATA_HOME") {
-        return PathBuf::from(data_home)
-            .join("falcon-cli")
-            .join("session.json");
+        return PathBuf::from(data_home).join("falcon-cli").join(file_name);
     }
     if let Ok(home) = std::env::var("HOME") {
         return PathBuf::from(home)
             .join(".local")
             .join("share")
             .join("falcon-cli")
-            .join("session.json");
+            .join(file_name);
     }
-    PathBuf::from("/tmp/falcon-cli-session.json")
+    PathBuf::from(format!("/tmp/falcon-cli-{file_name}"))
 }
 
 /// Write session info to disk with restricted permissions (0600).
@@ -96,8 +105,9 @@ mod tests {
 
     #[test]
     fn test_session_file_path_default() {
+        // Tests run as debug builds, so the file name should be session.debug.json.
         let path = session_file_path();
-        assert_eq!(path.file_name().unwrap(), "session.json");
+        assert_eq!(path.file_name().unwrap(), "session.debug.json");
         assert!(path.to_string_lossy().contains("falcon-cli"));
     }
 


### PR DESCRIPTION
## What

debug build と release build でセッションファイルを分離し、並行実行時のファイル競合を防止します。

## Why

同一マシンで `cargo build`（debug）と `cargo build --release` を並行実行すると、両方が同じ `session.json` に書き込み、セッション情報が上書き・破壊される問題があります。

mde-cli での同様の対応 (https://github.com/hiboma/mde-cli/pull/9) と同じデザインを falcon-cli にも取り込みます。

## How

- `session_file_name()` 関数を追加し、`cfg!(debug_assertions)` でビルドプロファイルを判定します
  - debug build: `session.debug.json`
  - release build: `session.json`
- `session_file_path()` がこの関数を使用するように更新しました
- テストの期待値を `session.debug.json` に修正しました

## Test plan

- [x] `cargo test` - セッション関連テスト3件 pass
- [x] `cargo fmt --check` - pass
- [x] `cargo clippy -- -D warnings` - pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)