### PR TITLE
feat: add report-execution download command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ dependencies = [
 name = "falcon-cli"
 version = "0.8.0"
 dependencies = [
+ "base64",
  "chrono",
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ toml = "1.1"
 chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 clap_complete = "4.6.0"
+base64 = "0.22"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"

--- a/src/client.rs
+++ b/src/client.rs
@@ -92,6 +92,22 @@ impl FalconClient {
         Self::handle_response(resp).await
     }
 
+    /// Send a GET request and return raw bytes with automatic re-authentication on 401.
+    pub async fn get_bytes(&self, path: &str) -> Result<Vec<u8>> {
+        let url = format!("{}{}", self.base_url, path);
+        let token = self.auth.get_token().await?;
+        let resp = self.http.get(&url).bearer_auth(&token).send().await?;
+
+        if resp.status() == StatusCode::UNAUTHORIZED {
+            self.auth.invalidate().await;
+            let new_token = self.auth.refresh_token().await?;
+            let retry_resp = self.http.get(&url).bearer_auth(&new_token).send().await?;
+            return Self::handle_bytes_response(retry_resp).await;
+        }
+
+        Self::handle_bytes_response(resp).await
+    }
+
     /// Send a DELETE request with automatic re-authentication on 401.
     #[allow(dead_code)]
     pub async fn delete(&self, path: &str) -> Result<serde_json::Value> {
@@ -126,5 +142,19 @@ impl FalconClient {
 
         let value: serde_json::Value = serde_json::from_str(&body)?;
         Ok(value)
+    }
+
+    async fn handle_bytes_response(resp: reqwest::Response) -> Result<Vec<u8>> {
+        let status = resp.status();
+
+        if !status.is_success() {
+            let body = resp.text().await?;
+            let mut truncated = body;
+            truncated.truncate(200);
+            return Err(FalconError::Api(format!("{}: {}", status, truncated)));
+        }
+
+        let bytes = resp.bytes().await?;
+        Ok(bytes.to_vec())
     }
 }

--- a/src/commands/report_executions.rs
+++ b/src/commands/report_executions.rs
@@ -1,8 +1,9 @@
 use clap::Subcommand;
+use std::io::Write;
 
 use crate::client::FalconClient;
 use crate::commands::build_query_path;
-use crate::error::Result;
+use crate::error::{FalconError, Result};
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -36,6 +37,19 @@ pub enum Action {
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },
+    /// Download report execution result
+    ///
+    /// Downloads the report data (typically gzip-compressed CSV) for a given
+    /// report execution ID. Writes to a file or stdout.
+    Download {
+        /// Report execution ID
+        #[arg(long, required = true)]
+        id: String,
+
+        /// Output file path (default: stdout)
+        #[arg(long, short)]
+        output: Option<String>,
+    },
 }
 
 pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json::Value> {
@@ -57,6 +71,27 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
             let ids: Vec<String> = id.iter().map(|i| format!("ids={}", i)).collect();
             let path = format!("/reports/entities/report-executions/v1?{}", ids.join("&"));
             client.get(&path).await
+        }
+        Action::Download { id, output } => {
+            let path = format!("/reports/entities/report-executions-download/v1?ids={}", id);
+            let data = client.get_bytes(&path).await?;
+
+            match output {
+                Some(file_path) => {
+                    std::fs::write(&file_path, &data).map_err(|e| {
+                        FalconError::Api(format!("failed to write {}: {}", file_path, e))
+                    })?;
+                    eprintln!("Downloaded {} bytes to {}", data.len(), file_path);
+                }
+                None => {
+                    let mut stdout = std::io::stdout().lock();
+                    stdout
+                        .write_all(&data)
+                        .map_err(|e| FalconError::Api(format!("failed to write stdout: {}", e)))?;
+                }
+            }
+
+            Ok(serde_json::json!({"status": "downloaded", "bytes": data.len()}))
         }
     }
 }

--- a/src/commands/report_executions.rs
+++ b/src/commands/report_executions.rs
@@ -1,9 +1,9 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
 use clap::Subcommand;
-use std::io::Write;
 
 use crate::client::FalconClient;
 use crate::commands::build_query_path;
-use crate::error::{FalconError, Result};
+use crate::error::Result;
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -75,23 +75,14 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
         Action::Download { id, output } => {
             let path = format!("/reports/entities/report-executions-download/v1?ids={}", id);
             let data = client.get_bytes(&path).await?;
+            let encoded = STANDARD.encode(&data);
 
-            match output {
-                Some(file_path) => {
-                    std::fs::write(&file_path, &data).map_err(|e| {
-                        FalconError::Api(format!("failed to write {}: {}", file_path, e))
-                    })?;
-                    eprintln!("Downloaded {} bytes to {}", data.len(), file_path);
-                }
-                None => {
-                    let mut stdout = std::io::stdout().lock();
-                    stdout
-                        .write_all(&data)
-                        .map_err(|e| FalconError::Api(format!("failed to write stdout: {}", e)))?;
-                }
-            }
-
-            Ok(serde_json::json!({"status": "downloaded", "bytes": data.len()}))
+            Ok(serde_json::json!({
+                "_binary": true,
+                "data": encoded,
+                "bytes": data.len(),
+                "output": output,
+            }))
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -284,12 +284,15 @@ mod tests {
     }
 
     /// Helper to ensure FALCON_* env vars are cleared before tests that call resolve().
+    /// Also redirects XDG_CONFIG_HOME/HOME to prevent loading credentials.toml.
     unsafe fn clear_falcon_env() {
         unsafe {
             std::env::remove_var("FALCON_CLIENT_ID");
             std::env::remove_var("FALCON_CLIENT_SECRET");
             std::env::remove_var("FALCON_BASE_URL");
             std::env::remove_var("FALCON_MEMBER_CID");
+            std::env::set_var("XDG_CONFIG_HOME", "/nonexistent");
+            std::env::set_var("HOME", "/nonexistent");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,12 @@ mod error;
 mod output;
 mod profile;
 
+use base64::{engine::general_purpose::STANDARD, Engine};
 use clap::{CommandFactory, Parser};
 use cli::{AgentAction, Cli, Command, ProfileAction};
 use config::FalconCredentials;
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::Arc;
 
 fn main() {
@@ -128,7 +130,11 @@ async fn async_main(cli: Cli, credentials: FalconCredentials) {
 
     match result {
         Ok(value) => {
-            output::print_value(&value, &cli.output, cli.pretty);
+            if is_binary_response(&value) {
+                write_binary_response(&value);
+            } else {
+                output::print_value(&value, &cli.output, cli.pretty);
+            }
         }
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -557,7 +563,11 @@ async fn handle_agent_client(cli: &Cli) {
 
     match result {
         Ok(value) => {
-            output::print_value(&value, &cli.output, cli.pretty);
+            if is_binary_response(&value) {
+                write_binary_response(&value);
+            } else {
+                output::print_value(&value, &cli.output, cli.pretty);
+            }
         }
         Err(e) => {
             eprintln!("Error (via agent at {}): {}", socket_path.display(), e);
@@ -583,7 +593,11 @@ async fn handle_agent_client_from_session(cli: &Cli, session: agent::session::Se
 
     match result {
         Ok(value) => {
-            output::print_value(&value, &cli.output, cli.pretty);
+            if is_binary_response(&value) {
+                write_binary_response(&value);
+            } else {
+                output::print_value(&value, &cli.output, cli.pretty);
+            }
         }
         Err(e) => {
             eprintln!("Error (via agent at {}): {}", socket_path.display(), e);
@@ -820,5 +834,48 @@ fn insert_arg(args: &mut HashMap<String, serde_json::Value>, key: String, value:
         }
     } else {
         args.insert(key, serde_json::Value::String(value));
+    }
+}
+
+/// Check if a response contains binary data encoded as base64.
+fn is_binary_response(value: &serde_json::Value) -> bool {
+    value.get("_binary").and_then(|v| v.as_bool()) == Some(true)
+}
+
+/// Decode base64 binary data from a response and write to file or stdout.
+fn write_binary_response(value: &serde_json::Value) {
+    let encoded = match value.get("data").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => {
+            eprintln!("Error: binary response missing data field");
+            std::process::exit(1);
+        }
+    };
+
+    let data = match STANDARD.decode(encoded) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Error: failed to decode binary data: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let output_path = value.get("output").and_then(|v| v.as_str());
+
+    match output_path {
+        Some(file_path) => {
+            if let Err(e) = std::fs::write(file_path, &data) {
+                eprintln!("Error: failed to write {}: {}", file_path, e);
+                std::process::exit(1);
+            }
+            eprintln!("Downloaded {} bytes to {}", data.len(), file_path);
+        }
+        None => {
+            let mut stdout = std::io::stdout().lock();
+            if let Err(e) = stdout.write_all(&data) {
+                eprintln!("Error: failed to write stdout: {}", e);
+                std::process::exit(1);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

`falcon-cli report-execution download` command to download Scheduled Search report results via CLI.

## Why

When Slack notifications arrive for Scheduled Search results, the only way to access the report data was through the Falcon console. This command enables downloading report data directly from the CLI using the execution ID provided in the notification, eliminating the need to log into the console.

Example from Slack notification:
> *API download URI:* `/reports/entities/report-executions-download/v1?ids=019d22b94eac7deb9fe0eedb83f47104`

## How

- Added `get_bytes()` method to `FalconClient` for binary data endpoints (with 401 retry logic)
- Added `Download` action to `report-execution` command
  - `--id` (required): report execution ID
  - `--output` / `-o` (optional): output file path (defaults to stdout)

## Usage

```bash
# Download to file
falcon-cli report-execution download --id <execution_id> -o report.gz

# Pipe to stdout
falcon-cli report-execution download --id <execution_id> > report.gz

# Pipe through gunzip
falcon-cli report-execution download --id <execution_id> | gunzip | jq .
```

## Test plan

- [x] `cargo test` - all 35 tests passed
- [x] `cargo fmt --check` - passed
- [x] `cargo clippy -- -D warnings` - passed
- [ ] Manual test with real execution ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)