### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary

Bump version to 0.7.0 for release.

## Changes in v0.7.0

- **FalconCredentials struct**: Credentials resolved once at startup, cleared from env before fork
- **Eval mode removed**: Agent always uses session.json for cross-terminal auto-detection
- **Watchdog removed**: Signal-only shutdown (SIGTERM/SIGINT)
- **Agent UX improved**: `agent stop` reads session.json automatically, `agent status` simplified
- **Security**: `overwrite_environ_value()` scrubs C environ array before fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)