### PR TITLE
feat: support credentials.toml with XDG Base Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env.*
 *.pem
 *.key
+.falcon-credentials.toml

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Set the following environment variables:
 
 CLI options (`--client-id`, `--base-url`, `--member-cid`) override environment variables.
 
-> **Note:** `FALCON_CLIENT_SECRET` is only configurable via environment variable or `.env` file to prevent exposure in process lists. Ensure `.env` files have restrictive permissions (`chmod 600 .env`).
+> **Note:** `FALCON_CLIENT_SECRET` has no CLI flag to prevent exposure in process lists. Use environment variables, `.env` files, or `credentials.toml`. Ensure these files have restrictive permissions (`chmod 600`).
 
 ### Credentials File (TOML)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ cargo install --path .
 
 ## Configuration
 
+### Environment Variables
+
 Set the following environment variables:
 
 | Variable | Required | Description |
@@ -53,6 +55,59 @@ Set the following environment variables:
 CLI options (`--client-id`, `--base-url`, `--member-cid`) override environment variables.
 
 > **Note:** `FALCON_CLIENT_SECRET` is only configurable via environment variable or `.env` file to prevent exposure in process lists. Ensure `.env` files have restrictive permissions (`chmod 600 .env`).
+
+### Credentials File (TOML)
+
+You can configure credentials using a `credentials.toml` file. Files are loaded in the following order:
+
+1. `./.falcon-credentials.toml` (project-local)
+2. `$XDG_CONFIG_HOME/falcon-cli/credentials.toml` (default: `~/.config/falcon-cli/credentials.toml`)
+
+Priority: CLI arguments > environment variables > credentials.toml
+
+Template:
+
+```toml
+# falcon-cli credentials configuration
+#
+# Security notes:
+#   - This file contains sensitive information
+#   - Set file permissions to 0600: chmod 600 credentials.toml
+#   - Add to .gitignore to prevent committing to the repository
+#   - Consider using environment variables or a secrets manager instead
+
+[credentials]
+# CrowdStrike Falcon API OAuth2 client ID (required)
+client_id = ""
+
+# CrowdStrike Falcon API OAuth2 client secret (required)
+client_secret = ""
+
+# API base URL (optional)
+# Default: https://api.crowdstrike.com
+# US-2: https://api.us-2.crowdstrike.com
+# EU-1: https://api.eu-1.crowdstrike.com
+# US-GOV-1: https://api.laggar.gcw.crowdstrike.com
+# base_url = "https://api.crowdstrike.com"
+
+# Member CID for MSSP (optional)
+# Set this to specify a child tenant in multi-tenant environments
+# member_cid = ""
+```
+
+Setup:
+
+```bash
+# Global configuration (XDG Base Directory)
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/falcon-cli"
+cp credentials.toml "${XDG_CONFIG_HOME:-$HOME/.config}/falcon-cli/credentials.toml"
+chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/falcon-cli/credentials.toml"
+
+# Project-local configuration
+cp credentials.toml .falcon-credentials.toml
+chmod 600 .falcon-credentials.toml
+echo ".falcon-credentials.toml" >> .gitignore
+```
 
 ## Agent Mode
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,12 +58,24 @@ fn credentials_search_paths() -> Vec<PathBuf> {
     paths
 }
 
+/// Filter empty strings to None so that unfilled template values
+/// (e.g. `client_id = ""`) do not bypass validation.
+fn non_empty(s: Option<String>) -> Option<String> {
+    s.filter(|v| !v.is_empty())
+}
+
 /// Load credentials from the first credentials.toml found.
 fn load_credentials_file() -> CredentialsFile {
     for path in credentials_search_paths() {
         if let Ok(content) = std::fs::read_to_string(&path) {
             if let Ok(root) = toml::from_str::<CredentialsFileRoot>(&content) {
-                return root.credentials;
+                let c = root.credentials;
+                return CredentialsFile {
+                    client_id: non_empty(c.client_id),
+                    client_secret: non_empty(c.client_secret),
+                    base_url: non_empty(c.base_url),
+                    member_cid: non_empty(c.member_cid),
+                };
             }
         }
     }
@@ -384,15 +396,13 @@ client_secret = "toml-secret"
     }
 
     #[test]
-    fn test_credentials_file_empty_values_ignored() {
-        let toml_str = r#"
-[credentials]
-client_id = ""
-client_secret = ""
-"#;
-        let root: CredentialsFileRoot = toml::from_str(toml_str).unwrap();
-        // Empty strings are parsed as Some(""), not None
-        assert_eq!(root.credentials.client_id.as_deref(), Some(""));
+    fn test_non_empty_filters_empty_strings() {
+        assert_eq!(non_empty(Some("".to_string())), None);
+        assert_eq!(
+            non_empty(Some("value".to_string())),
+            Some("value".to_string())
+        );
+        assert_eq!(non_empty(None), None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,6 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
 use crate::error::{FalconError, Result};
 
 #[derive(Debug, Clone)]
@@ -8,7 +11,23 @@ pub struct Config {
     pub member_cid: Option<String>,
 }
 
-/// Resolved Falcon API credentials collected from CLI args and environment variables.
+/// TOML representation of `[credentials]` in credentials.toml.
+#[derive(Debug, Deserialize, Default)]
+struct CredentialsFileRoot {
+    #[serde(default)]
+    credentials: CredentialsFile,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct CredentialsFile {
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    base_url: Option<String>,
+    member_cid: Option<String>,
+}
+
+/// Resolved Falcon API credentials collected from CLI args, environment variables,
+/// and credentials.toml.
 /// Once constructed, the process should call `FalconCredentials::clear_env()` to remove
 /// credential environment variables so that forked child processes do not inherit them.
 #[derive(Debug, Clone, Default)]
@@ -19,28 +38,67 @@ pub struct FalconCredentials {
     pub member_cid: Option<String>,
 }
 
+/// Search paths for credentials.toml (highest priority first).
+fn credentials_search_paths() -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from(".falcon-credentials.toml")];
+    if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
+        paths.push(
+            PathBuf::from(config_home)
+                .join("falcon-cli")
+                .join("credentials.toml"),
+        );
+    } else if let Ok(home) = std::env::var("HOME") {
+        paths.push(
+            PathBuf::from(home)
+                .join(".config")
+                .join("falcon-cli")
+                .join("credentials.toml"),
+        );
+    }
+    paths
+}
+
+/// Load credentials from the first credentials.toml found.
+fn load_credentials_file() -> CredentialsFile {
+    for path in credentials_search_paths() {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Ok(root) = toml::from_str::<CredentialsFileRoot>(&content) {
+                return root.credentials;
+            }
+        }
+    }
+    CredentialsFile::default()
+}
+
 impl FalconCredentials {
-    /// Resolve credentials from CLI args and environment variables.
-    /// Priority: CLI args > environment variables > defaults.
+    /// Resolve credentials from CLI args, environment variables, and credentials.toml.
+    /// Priority: CLI args > environment variables > credentials.toml > defaults.
     pub fn resolve(
         cli_client_id: Option<&str>,
         cli_base_url: Option<&str>,
         cli_member_cid: Option<&str>,
     ) -> Self {
+        let file = load_credentials_file();
+
         let client_id = cli_client_id
             .map(String::from)
-            .or_else(|| std::env::var("FALCON_CLIENT_ID").ok());
+            .or_else(|| std::env::var("FALCON_CLIENT_ID").ok())
+            .or(file.client_id);
 
-        let client_secret = std::env::var("FALCON_CLIENT_SECRET").ok();
+        let client_secret = std::env::var("FALCON_CLIENT_SECRET")
+            .ok()
+            .or(file.client_secret);
 
         let base_url = cli_base_url
             .map(String::from)
             .or_else(|| std::env::var("FALCON_BASE_URL").ok())
+            .or(file.base_url)
             .unwrap_or_else(|| "https://api.crowdstrike.com".to_string());
 
         let member_cid = cli_member_cid
             .map(String::from)
-            .or_else(|| std::env::var("FALCON_MEMBER_CID").ok());
+            .or_else(|| std::env::var("FALCON_MEMBER_CID").ok())
+            .or(file.member_cid);
 
         Self {
             client_id,
@@ -280,6 +338,61 @@ mod tests {
         assert!(std::env::var("FALCON_CLIENT_SECRET").is_err());
         assert!(std::env::var("FALCON_BASE_URL").is_err());
         assert!(std::env::var("FALCON_MEMBER_CID").is_err());
+    }
+
+    #[test]
+    fn test_credentials_file_parse_full() {
+        let toml_str = r#"
+[credentials]
+client_id = "toml-id"
+client_secret = "toml-secret"
+base_url = "https://api.eu-1.crowdstrike.com"
+member_cid = "toml-cid"
+"#;
+        let root: CredentialsFileRoot = toml::from_str(toml_str).unwrap();
+        assert_eq!(root.credentials.client_id.as_deref(), Some("toml-id"));
+        assert_eq!(
+            root.credentials.client_secret.as_deref(),
+            Some("toml-secret")
+        );
+        assert_eq!(
+            root.credentials.base_url.as_deref(),
+            Some("https://api.eu-1.crowdstrike.com")
+        );
+        assert_eq!(root.credentials.member_cid.as_deref(), Some("toml-cid"));
+    }
+
+    #[test]
+    fn test_credentials_file_parse_minimal() {
+        let toml_str = r#"
+[credentials]
+client_id = "toml-id"
+client_secret = "toml-secret"
+"#;
+        let root: CredentialsFileRoot = toml::from_str(toml_str).unwrap();
+        assert_eq!(root.credentials.client_id.as_deref(), Some("toml-id"));
+        assert!(root.credentials.base_url.is_none());
+        assert!(root.credentials.member_cid.is_none());
+    }
+
+    #[test]
+    fn test_credentials_file_parse_empty() {
+        let toml_str = "";
+        let root: CredentialsFileRoot = toml::from_str(toml_str).unwrap();
+        assert!(root.credentials.client_id.is_none());
+        assert!(root.credentials.client_secret.is_none());
+    }
+
+    #[test]
+    fn test_credentials_file_empty_values_ignored() {
+        let toml_str = r#"
+[credentials]
+client_id = ""
+client_secret = ""
+"#;
+        let root: CredentialsFileRoot = toml::from_str(toml_str).unwrap();
+        // Empty strings are parsed as Some(""), not None
+        assert_eq!(root.credentials.client_id.as_deref(), Some(""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add TOML-based credential configuration as an alternative to environment variables, following XDG Base Directory specification.

- Load credentials from `.falcon-credentials.toml` (project-local) or `$XDG_CONFIG_HOME/falcon-cli/credentials.toml` (global)
- Priority: CLI args > environment variables > credentials.toml > defaults
- Filter empty string values from TOML to prevent unfilled templates from bypassing validation
- Add `.falcon-credentials.toml` to `.gitignore`
- Document the setup in README

## Test plan

- [x] Unit tests for TOML parsing (full, minimal, empty)
- [x] Unit test for `non_empty()` filter
- [x] All existing tests pass (`cargo test -- --test-threads=1`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

## Follow-up

- [ ] File permission check (warn/reject if credentials.toml is world-readable)
- [ ] stderr warning on TOML parse failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)