### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary

Bump version to 0.8.0 for release.

### Changes since v0.7.0

- **feat**: credentials.toml support with XDG Base Directory (#43)
- **fix**: CVE fix for rustls-webpki, CI test thread race condition (#42)
- **chore**: dependabot configuration, dependency updates (#31-#41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)