### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary
- Bump version from 0.8.0 to 0.9.0 for the next release

## Changes since v0.8.0
- fix: use session.json PID for agent stop instead of PID file (#46)
- feat: add report-execution download command (#28)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>