### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,35 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 6 * * 1"
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,7 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       security-events: write
       id-token: write


### PR DESCRIPTION
## What

Add weekly security posture assessment using OpenSSF Scorecard with SARIF upload to the GitHub Security tab.

## Why

Continuous monitoring of the project's security posture helps identify supply chain risks, missing security practices, and areas for improvement. OpenSSF Scorecard provides automated, standardized scoring across multiple security dimensions.

## How

- Added `.github/workflows/scorecard.yml`
- Runs on schedule (Monday 06:00 UTC), on push to main, and on branch protection rule changes
- Uploads SARIF results to the Security tab for integrated visibility
- Follows project security guidelines: all actions pinned by commit SHA, minimal permissions (`permissions: {}` at workflow level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)