### PR TITLE
fix: resolve code scanning alerts (HTTPS enforcement, Actions pinning, token permissions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt, clippy
@@ -42,7 +42,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}
@@ -38,17 +38,19 @@ jobs:
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../falcon-cli-${{ matrix.target }}.tar.gz falcon-cli
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: falcon-cli-${{ matrix.target }}
           path: falcon-cli-${{ matrix.target }}.*
 
   release:
+    permissions:
+      contents: write
     name: Release
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,10 +11,7 @@ pub struct FalconClient {
 
 impl FalconClient {
     pub fn new(auth: Auth, base_url: String) -> Result<Self> {
-        if !base_url.starts_with("https://")
-            && !base_url.starts_with("http://localhost")
-            && !base_url.starts_with("http://127.0.0.1")
-        {
+        if !base_url.starts_with("https://") && !Self::is_loopback_http(&base_url) {
             return Err(FalconError::Config(format!(
                 "base_url must use HTTPS (got: {}). HTTP is only allowed for localhost and 127.0.0.1.",
                 base_url
@@ -166,5 +163,49 @@ impl FalconClient {
 
         let bytes = resp.bytes().await?;
         Ok(bytes.to_vec())
+    }
+
+    fn is_loopback_http(url: &str) -> bool {
+        for prefix in &["http://localhost", "http://127.0.0.1"] {
+            if let Some(rest) = url.strip_prefix(prefix) {
+                if rest.is_empty() || rest.starts_with(':') || rest.starts_with('/') {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_loopback_http_localhost() {
+        assert!(FalconClient::is_loopback_http("http://localhost"));
+        assert!(FalconClient::is_loopback_http("http://localhost:8080"));
+        assert!(FalconClient::is_loopback_http("http://localhost/path"));
+    }
+
+    #[test]
+    fn test_is_loopback_http_127_0_0_1() {
+        assert!(FalconClient::is_loopback_http("http://127.0.0.1"));
+        assert!(FalconClient::is_loopback_http("http://127.0.0.1:9999"));
+        assert!(FalconClient::is_loopback_http("http://127.0.0.1/path"));
+    }
+
+    #[test]
+    fn test_is_loopback_http_rejects_subdomain_bypass() {
+        assert!(!FalconClient::is_loopback_http("http://localhost.evil.com"));
+        assert!(!FalconClient::is_loopback_http("http://127.0.0.1.evil.com"));
+    }
+
+    #[test]
+    fn test_is_loopback_http_rejects_non_loopback() {
+        assert!(!FalconClient::is_loopback_http("http://example.com"));
+        assert!(!FalconClient::is_loopback_http("https://localhost"));
+        assert!(!FalconClient::is_loopback_http("ftp://localhost"));
+        assert!(!FalconClient::is_loopback_http(""));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,13 +10,23 @@ pub struct FalconClient {
 }
 
 impl FalconClient {
-    pub fn new(auth: Auth, base_url: String) -> Self {
+    pub fn new(auth: Auth, base_url: String) -> Result<Self> {
+        if !base_url.starts_with("https://")
+            && !base_url.starts_with("http://localhost")
+            && !base_url.starts_with("http://127.0.0.1")
+        {
+            return Err(FalconError::Config(format!(
+                "base_url must use HTTPS (got: {}). HTTP is only allowed for localhost and 127.0.0.1.",
+                base_url
+            )));
+        }
+
         let http = reqwest::Client::new();
-        Self {
+        Ok(Self {
             auth,
             http,
             base_url,
-        }
+        })
     }
 
     /// Send a GET request with automatic re-authentication on 401.

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,10 @@ async fn async_main(cli: Cli, credentials: FalconCredentials) {
     };
 
     let auth = auth::Auth::new(config.clone());
-    let falcon = client::FalconClient::new(auth, config.base_url.clone());
+    let falcon = client::FalconClient::new(auth, config.base_url.clone()).unwrap_or_else(|e| {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    });
 
     let result = dispatch::execute(&falcon, cli.command).await;
 
@@ -484,7 +487,10 @@ fn handle_agent_start(
     };
 
     let auth = auth::Auth::new(config_obj.clone());
-    let falcon = client::FalconClient::new(auth, config_obj.base_url.clone());
+    let falcon = client::FalconClient::new(auth, config_obj.base_url.clone()).unwrap_or_else(|e| {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    });
     let falcon = Arc::new(falcon);
 
     let socket_path = match socket {


### PR DESCRIPTION
## Motivation

Address open Code Scanning alerts reported by OpenSSF Scorecard and CodeQL.
This PR resolves 15 of 22 alerts — the remaining 7 require repository-level configuration changes (Branch Protection, Security Policy, etc.) that cannot be fixed via code.

## What

### HTTPS enforcement for base_url (CodeQL #1-#8: `rust/cleartext-transmission`)

- Validate that `base_url` uses HTTPS in `FalconClient::new()`, rejecting plain HTTP URLs that would transmit bearer tokens in cleartext
- `http://localhost` and `http://127.0.0.1` are exempted for local development/testing, with strict boundary checking to prevent subdomain bypass (e.g., `http://localhost.evil.com` is rejected)

### Pin GitHub Actions by commit hash (Scorecard #10-#14: `Pinned-Dependencies`)

- `actions/checkout@v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- `actions/upload-artifact@v7` → `@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0`
- `actions/download-artifact@v8` → `@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1`

### Scope token permissions (Scorecard #15: `Token-Permissions`)

- Change top-level `permissions` in `release.yml` from `contents: write` to `contents: read`
- Grant `contents: write` only to the `release` job that actually needs it

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 45 unit tests pass (including 4 new tests for loopback validation)
- [ ] CI workflow runs successfully with pinned action hashes
- [ ] Verify Scorecard re-scan reflects resolved alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)