### PR TITLE
fix: handle shell completion before auth and agent routing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,17 @@ fn main() {
 
     let cli = Cli::parse();
 
+    // Handle shell completion generation early (no auth, no agent, no tokio needed).
+    if let Command::Completion { shell } = cli.command {
+        clap_complete::generate(
+            shell,
+            &mut Cli::command(),
+            "falcon-cli",
+            &mut std::io::stdout(),
+        );
+        return;
+    }
+
     // Resolve credentials early (before fork).
     let credentials = FalconCredentials::resolve(
         cli.client_id.as_deref(),
@@ -85,17 +96,6 @@ async fn async_main(cli: Cli, credentials: FalconCredentials) {
                 return;
             }
         }
-    }
-
-    // Handle shell completion generation.
-    if let Command::Completion { shell } = cli.command {
-        clap_complete::generate(
-            shell,
-            &mut Cli::command(),
-            "falcon-cli",
-            &mut std::io::stdout(),
-        );
-        return;
     }
 
     // Check profile restrictions before dispatching.


### PR DESCRIPTION
## Motivation

Make `falcon-cli completion <shell>` work reliably in every environment, including when a credential agent is already running. Shell completion should never depend on authentication or agent state because users generate the script once during setup.

## Why

`Command::Completion` was processed inside `async_main`, **after** the block that auto-detects a running agent from `session.json`. Once `falcon-cli agent start` had been invoked, a subsequent `falcon-cli completion zsh > ~/.zfunc/_falcon-cli` was routed through the agent client as if it were a regular API request, and failed instead of emitting the completion script. Users who followed the README instructions from #7 could not regenerate their completion script while the agent was active.

Completion generation needs neither credentials, the agent, nor a tokio runtime, so the fix is to run it as early as possible.

## How

Move the `Command::Completion` branch to the top of `main()`, right after `Cli::parse()`. This runs before credential resolution, before the `agent start` fork path, before tokio runtime creation, and before the session-based agent auto-detection in `async_main`. The duplicate block previously sitting in `async_main` is removed.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — all tests pass except the pre-existing, environment-dependent `test_missing_credentials_error` (fails on `main` too when `FALCON_CLIENT_ID` is set in the environment)
- [x] `falcon-cli completion zsh`, `bash`, `fish` each emit a valid completion script
- [ ] Verified against a running agent (`falcon-cli agent start` → `falcon-cli completion zsh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)