### PR TITLE
chore: bump version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary

- バージョンを 0.9.1 に bump します
- v0.9.0 以降の fix、ci、依存関係更新をリリースするためのバージョン bump です

## Changes since v0.9.0

### Fixes
- fix: handle shell completion before auth and agent routing (#56)
- fix: resolve code scanning alerts (HTTPS enforcement, Actions pinning, token permissions) (#55)

### CI / Docs
- ci: add OpenSSF Scorecard workflow (#48)
- docs: update README.md to match current codebase v0.9.0 (#54)

### Dependencies
- chore(deps): bump tokio from 1.50.0 to 1.51.0 (#53)
- chore(deps): bump toml from 1.1.0 to 1.1.2 (#52)
- chore(deps): bump github/codeql-action from 3.35.1 to 4.35.1 (#51)
- chore(deps): bump libc from 0.2.183 to 0.2.184 (#50)
- chore(deps): bump actions/checkout from 4.2.2 to 6.0.2 (#49)

## Test plan

- [ ] CI が成功すること
- [ ] merge 後に tag `v0.9.1` を push して release workflow が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)