### PR TITLE
ci: add cargo-deny supply-chain checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Test
         run: cargo test -- --test-threads=1
 
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
+        with:
+          command: check
+          arguments: --all-features
+
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ cargo build
 cargo test
 cargo fmt --check
 cargo clippy -- -D warnings
+cargo deny check
 ```
 
 ## Authentication
@@ -53,6 +54,7 @@ cargo clippy -- -D warnings
 - Pin all third-party actions by commit hash
 - Validate all user input strictly
 - Use `pull_request` (not `pull_request_target`)
+- Supply chain checks via `cargo-deny` (advisories, licenses, bans, sources) are enforced in CI. Policy lives in `deny.toml`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -518,7 +518,10 @@ cargo build
 cargo test
 cargo fmt --check
 cargo clippy -- -D warnings
+cargo deny check
 ```
+
+`cargo deny check` enforces supply-chain policy (advisories, licenses, bans, sources) declared in `deny.toml`. Install the binary with `cargo install --locked cargo-deny` if it is not yet available locally.
 
 ## License
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,51 @@
+[graph]
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+ignore = []
+
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+exceptions = []
+
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

- Add `deny.toml` enabling all four checks: `advisories`, `licenses`, `bans`, and `sources`.
- Add a `cargo-deny` job to `.github/workflows/ci.yml` so `cargo deny check` runs on every push and pull request.
- Document `cargo deny check` in the Build/Test sections of `CLAUDE.md` and `README.md`.

## Background

The existing CI only runs `cargo fmt`, `cargo clippy`, and `cargo test`, so it does not audit dependencies for known vulnerabilities (RustSec), license compliance, or source provenance. GitHub Actions-side supply-chain hardening (OpenSSF Scorecard, pinact) is already in place, but the Rust dependency side had no continuous monitoring. Introducing cargo-deny adds: continuous matching against the RustSec Advisory DB, license compliance enforcement, visibility into duplicate versions, and rejection of registries/git sources other than crates.io — all in one step.

## deny.toml policy

- **advisories**: `yanked = "deny"`. Matched against the RustSec Advisory DB.
- **licenses**: Allowlist derived from the current dependency tree. Allowed: Apache-2.0, Apache-2.0 WITH LLVM-exception, MIT, BSD-3-Clause, BSL-1.0, CDLA-Permissive-2.0, ISC, Unicode-3.0, Unlicense, Zlib. GPL-family licenses are rejected.
- **bans**: `multiple-versions = "warn"` for now. `windows-sys` is currently duplicated between the rustls stack (v0.52) and the socket2/tokio stack (v0.60/v0.61); resolving this is non-trivial so it stays as a warning. Wildcard dependencies are denied.
- **sources**: Deny any registry other than crates.io, and deny git dependencies. No git dependencies exist today.

## Verification

- Ran `cargo deny check` locally: `advisories ok, bans ok, licenses ok, sources ok`.
- `cargo-deny-action` is pinned to `v2.0.16` by commit SHA (`175dc7fd4fb85ec8f46948fb98f44db001149081`), passing pinact.

## Test plan

- [ ] The `cargo-deny` CI job runs and succeeds on this PR.
- [ ] The `cargo-deny` job runs in parallel with, and independently of, `check` and `build`.
- [ ] Existing `check` and `build` jobs still succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)