### PR TITLE
feat(credentials): back client_secret with macOS Keychain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,17 +17,29 @@ cargo deny check
 ## Authentication
 
 - OAuth2 Client Credentials flow (POST /oauth2/token)
-- Priority: CLI options > environment variables
+- Priority for `client_id` / `base_url` / `member_cid`: CLI options > env vars > credentials.toml
+- Priority for `client_secret`: env var > macOS Keychain > credentials.toml
 - Tokens are held in memory only (no file persistence)
+- Recommended persistent store for `client_secret` is the macOS Keychain via `falcon-cli credentials set client-secret`
+- See `docs/adr/0005-keychain-backed-client-secret.md` for the resolve order, StoreError policy, and migrate flow
 
 ## Environment Variables
 
 - `FALCON_CLIENT_ID` - API client ID (required for direct mode)
-- `FALCON_CLIENT_SECRET` - API client secret (required for direct mode)
+- `FALCON_CLIENT_SECRET` - API client secret (optional; overrides Keychain when set)
 - `FALCON_BASE_URL` - Base URL (default: https://api.crowdstrike.com)
 - `FALCON_MEMBER_CID` - Member CID for MSSP (optional)
 - `FALCON_AGENT_SOCKET` - Agent Unix socket path (legacy, used by `--socket` flag)
 - `FALCON_AGENT_TOKEN` - Agent session token (legacy, triggers agent routing when set)
+
+## Credential Store (macOS Keychain)
+
+- Backend: `keyring` crate with `apple-native` feature
+- Keychain entry: `service=dev.falcon-cli`, `account=client_secret` in the login keychain
+- `StoreError::Unavailable` → falls through to `credentials.toml`
+- `StoreError::Backend` → does NOT fall through (prevents stale-toml override after Keychain migration)
+- `classify_keyring_err` downcasts to `security_framework::base::Error` and matches OSStatus `errSecNoDefaultKeychain` (-25307) / `errSecInvalidKeychain` (-25295), so locale-translated error messages (Japanese macOS etc.) still classify correctly
+- `falcon-cli credentials {set,delete,status,migrate}` manages entries; `get` is intentionally not provided to prevent AI-agent context leakage
 
 ## Agent Mode
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,16 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -298,19 +308,30 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
+ "keyring",
  "libc",
  "libproc",
  "reqwest",
+ "rpassword",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
  "uuid",
+ "zeroize",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -725,6 +746,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "zeroize",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +789,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1071,10 +1110,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1122,6 +1195,32 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework-sys"
@@ -1288,6 +1387,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1759,6 +1871,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2073,6 +2194,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,20 @@ chrono = { version = "0.4", features = ["serde"] }
 libc = "0.2"
 clap_complete = "4.6.0"
 base64 = "0.22"
+rpassword = "7"
+tempfile = "3"
+zeroize = { version = "1", features = ["zeroize_derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"
 security-framework-sys = "2"
 core-foundation = "0.10"
 core-foundation-sys = "0.8"
+keyring = { version = "3", default-features = false, features = ["apple-native"] }
+# Same major as the version that `keyring`'s apple-native backend pulls
+# in for macOS, so that downcasting the boxed error inside
+# keyring::Error::PlatformFailure resolves to the same `Error` type.
+security-framework = "3"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ echo "$FALCON_CLIENT_SECRET" | falcon-cli credentials set client-secret --stdin
 falcon-cli credentials status
 ```
 
+`--stdin` reads a single line and strips surrounding whitespace (leading and trailing ASCII + Unicode whitespace, including `\n` / `\r` / spaces / tabs). This defends against a stray trailing space pasted from a password manager silently corrupting the secret. If your `client_secret` can legitimately contain surrounding whitespace (unusual for CrowdStrike-issued values), use the interactive prompt instead.
+
 To migrate an existing plaintext `client_secret` from `credentials.toml` into the Keychain in one step:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,7 +58,91 @@ Set the following environment variables:
 
 CLI options (`--client-id`, `--base-url`, `--member-cid`) override environment variables.
 
-> **Note:** `FALCON_CLIENT_SECRET` has no CLI flag to prevent exposure in process lists. Use environment variables, `.env` files, or `credentials.toml`. Ensure these files have restrictive permissions (`chmod 600`).
+> **Note:** `FALCON_CLIENT_SECRET` has no CLI flag to prevent exposure in process lists. The recommended persistent store is the macOS Keychain (see below). Environment variables, `.env` files, and `credentials.toml` are still supported; ensure any on-disk file has restrictive permissions (`chmod 600`).
+
+### Credential storage (macOS Keychain)
+
+`falcon-cli` resolves the OAuth2 `client_secret` from the following sources, highest priority first:
+
+1. `FALCON_CLIENT_SECRET` environment variable
+2. **macOS Keychain** (login keychain, `service=dev.falcon-cli`, `account=client_secret`)
+3. `credentials.toml`, searched in this order:
+   1. `./.falcon-credentials.toml` (current working directory)
+   2. `$XDG_CONFIG_HOME/falcon-cli/credentials.toml` (falls back to `~/.config/falcon-cli/credentials.toml`)
+
+Storing the secret in the Keychain keeps it out of plaintext config files (and out of dotfile backups, Time Machine snapshots, accidental git commits, etc.).
+
+If the Keychain is available but returns a **backend error** (denied prompt, daemon down, ACL mismatch), `falcon-cli` deliberately refuses to fall back to `credentials.toml`. Silently picking up a stale plaintext value would defeat the point of moving the secret into the Keychain in the first place.
+
+#### Storing the secret
+
+```bash
+# Interactive prompt (recommended)
+falcon-cli credentials set client-secret
+
+# Non-interactive (CI / scripts)
+echo "$FALCON_CLIENT_SECRET" | falcon-cli credentials set client-secret --stdin
+
+# Confirm presence (the value is never printed)
+falcon-cli credentials status
+```
+
+To migrate an existing plaintext `client_secret` from `credentials.toml` into the Keychain in one step:
+
+```bash
+falcon-cli credentials migrate
+```
+
+`migrate` writes the secret to the Keychain and then offers to dispose of the plaintext copy:
+
+- **Recommended (default)**: the `client_secret` line is removed from the toml via an atomic temp-file rename. No plaintext copy remains on disk.
+- **Opt-in**: a 0o600 backup of the original toml is kept alongside the rewritten file. Choose this only if you need to roll back to the old setup.
+
+> ⚠️ **The opt-in backup still contains the plaintext secret.** A backup under `$HOME` is typically included in Time Machine / iCloud / rsync snapshots and defeats the point of moving the secret into the Keychain. Delete it as soon as you have confirmed the new setup works with `falcon-cli credentials status`.
+
+If the rewrite fails partway through, `migrate` rolls back the Keychain entry it just wrote so you are not left in a half-migrated state.
+
+#### Recovering from an interrupted migrate
+
+If you hit Ctrl-C (or your machine loses power) **between** the Keychain write and the toml rewrite, both copies of the secret exist: the new Keychain entry *and* the untouched `credentials.toml`. The process is idempotent — re-running `falcon-cli credentials migrate` on the same file will detect that the secret is still present in the toml and re-run the disposal step. Alternatively, if you want to bail out entirely, `falcon-cli credentials delete client-secret` removes the Keychain entry and the toml stays as it was.
+
+#### Inspecting the entry
+
+The entry lives in your **login** keychain as a `generic password`:
+
+| Attribute | Value |
+|---|---|
+| Kind | `application password` |
+| Service (Name / Where) | `dev.falcon-cli` |
+| Account | `client_secret` |
+
+GUI:
+
+```
+Keychain Access.app → login → Passwords → search "dev.falcon-cli"
+```
+
+CLI (metadata only):
+
+```bash
+security find-generic-password -s dev.falcon-cli -a client_secret
+```
+
+#### Removing the entry
+
+```bash
+falcon-cli credentials delete client-secret
+# or via macOS:
+security delete-generic-password -s dev.falcon-cli -a client_secret
+```
+
+#### Notes on Keychain prompts
+
+macOS shows an access-prompt dialog the first time `falcon-cli` reads the Keychain entry. Choosing **Always Allow** suppresses subsequent prompts.
+
+The dialog reappears whenever the binary's code signature changes — including after every `cargo install` rebuild. This is a macOS ACL behavior, not a `falcon-cli` bug.
+
+If a non-`falcon-cli` build of the binary keeps causing prompts, you can inspect the entry's Access Control list in Keychain Access.app and remove or replace the allowed-applications list.
 
 ### Credentials File (TOML)
 
@@ -67,7 +151,9 @@ You can configure credentials using a `credentials.toml` file. Files are loaded 
 1. `./.falcon-credentials.toml` (project-local)
 2. `$XDG_CONFIG_HOME/falcon-cli/credentials.toml` (default: `~/.config/falcon-cli/credentials.toml`)
 
-Priority: CLI arguments > environment variables > credentials.toml
+Priority for `client_id` / `base_url` / `member_cid`: CLI arguments > environment variables > credentials.toml.
+
+Priority for `client_secret`: `FALCON_CLIENT_SECRET` > macOS Keychain > credentials.toml. See [Credential storage (macOS Keychain)](#credential-storage-macos-keychain) above.
 
 Template:
 

--- a/docs/adr/0005-keychain-backed-client-secret.md
+++ b/docs/adr/0005-keychain-backed-client-secret.md
@@ -1,0 +1,295 @@
+# ADR-0005: Keychain による client_secret の保管
+
+## ステータス
+
+採択 (実装済み)
+
+## 日付
+
+2026-04-21
+
+## コンテキスト
+
+`falcon-cli` の OAuth2 `client_secret` は、これまで以下のいずれかでのみ
+保管されていました。
+
+- `FALCON_CLIENT_SECRET` 環境変数
+- `./.falcon-credentials.toml` または `~/.config/falcon-cli/credentials.toml`
+  に平文記載
+
+### 脅威
+
+平文ファイル保管には以下のリスクがあります。
+
+1. **バックアップ経由の漏洩**: Time Machine、iCloud Drive、`tar -czf`
+   など、ホームディレクトリ単位のバックアップに `client_secret` が
+   そのまま含まれます。バックアップは複製・配布されやすく、いったん
+   流出すると回収不可能です。
+2. **同一ユーザー権限のプロセスからの読み取り**: ファイルパーミッション
+   `0600` のみが防御層です。同じ uid で動く任意のマルウェア・スクリプト
+   が無条件に読めます。macOS Keychain は ACL で「特定の署名済みアプリの
+   み」に制限できます。
+3. **dotfiles リポジトリへの誤コミット**: `.gitignore` の漏れや
+   `git add -A` 経由で公開リポジトリに push される事故が起こりえます。
+4. **AI エージェントによるコンテキスト汚染**: Claude Code 等の LLM
+   エージェントが「設定確認のため」と称して `cat credentials.toml` を
+   実行し、出力が会話履歴・PR 説明・サポートログに残るリスクが
+   あります。
+
+### 制約
+
+- macOS 環境を主要ターゲットとします。Linux / Windows サポートは
+  trait 設計で将来追加可能とします。
+- 既存の toml 利用者がアップグレードしただけで挙動が変わらないこと
+  (後方互換)。
+- agent モード (ADR-0001) との整合性を保つこと。agent は親プロセスで
+  解決した credentials を子プロセスのメモリに渡すため、Keychain への
+  追加読み込みが per-request で発生してはなりません。
+- CI / sandbox 環境 (default keychain が無い) で resolve が破綻しない
+  こと。
+
+## 決定
+
+### CredentialStore trait による抽象化
+
+`src/config/credential_store.rs` に `CredentialStore` trait を定義し、
+プラットフォーム固有の保管バックエンドを抽象化します。
+
+```rust
+pub trait CredentialStore {
+    fn get(&self, key: &str) -> Result<Option<String>, StoreError>;
+    fn set(&self, key: &str, value: &str) -> Result<(), StoreError>;
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}
+```
+
+実装は 3 種類です。
+
+| 実装 | 用途 | 配置 |
+|---|---|---|
+| `KeychainStore` | macOS Keychain (本番) | `#[cfg(target_os = "macos")]` |
+| `MemoryStore` | テスト用 in-memory | `#[cfg(test)]` |
+| なし | 非 macOS ターゲット | `default_store()` が `None` を返す |
+
+`KeychainStore` は `keyring` crate (`apple-native` feature) 経由で
+`Security.framework` の `SecItemAdd` / `SecItemCopyMatching` を
+呼び出します。
+
+### Keychain エントリの属性
+
+| 属性 | 値 |
+|---|---|
+| Kind | `application password` (`kSecClassGenericPassword`) |
+| Service | `dev.falcon-cli` |
+| Account | `client_secret` |
+| Keychain | login (デフォルト) |
+
+Service 名は bundle identifier 風の固定文字列です。Account 名は
+`KEY_CLIENT_SECRET` 定数として `src/config/credential_store.rs` で
+公開しています。
+
+### Resolve の優先順位
+
+`FalconCredentials::resolve()` は client_secret を以下の順で解決します。
+
+```
+FALCON_CLIENT_SECRET (env) > Keychain > credentials.toml > None
+```
+
+client_id / base_url / member_cid は機密性が低いため Keychain に格納せず、
+CLI args > env > toml の従来順を維持します。
+
+### StoreError の分類とフォールバック判断
+
+`StoreError` を 2 variant に分けます。
+
+| Variant | 意味 | resolve の挙動 |
+|---|---|---|
+| `Unavailable(msg)` | 保管バックエンドそのものが存在しない (非 macOS、CI sandbox の default keychain なし) | 静かに toml にフォールバック |
+| `Backend(msg)` | バックエンドへのアクセスに失敗 (ユーザーが prompt を Deny、Keychain daemon ダウン、ACL 不整合) | **toml にフォールバックしない**。stderr に強い警告を出して `None` を返す |
+
+`Backend` 時に toml フォールバックを許可すると、Keychain に移行済みの
+ユーザーが Deny した瞬間に古い toml の secret が黙って採用されます。
+これは Keychain への移行という決定そのものを台無しにするため、
+明示的な失敗を選びます。
+
+### classify_keyring_err の OSStatus 判定
+
+`classify_keyring_err` は `keyring::Error::PlatformFailure` の source を
+`security_framework::base::Error` に downcast し、OSStatus で判定します。
+具体的には以下を `Unavailable` に分類します。
+
+| 定数 | OSStatus | 意味 |
+|---|---|---|
+| `errSecNoDefaultKeychain` | -25307 | default keychain が未設定 |
+| `errSecInvalidKeychain` | -25295 | keychain が invalid |
+
+文字列マッチ (`"no default keychain"` 等) は locale 翻訳 (日本語 macOS
+など) で外れることがあるため、OSStatus 判定を一次手段として採用し、
+文字列マッチは downcast が失敗した場合の last-resort fallback として
+残します。
+
+`security-framework` major を `3` に明示 pin しているのは、`keyring` v3
+の apple-native backend が内部で `security-framework 3.x` を使っている
+ため、downcast 対象の型が一致することを保証するためです。
+
+### `falcon-cli credentials` サブコマンド
+
+ユーザーが Keychain エントリを操作するためのサブコマンドを追加します。
+
+| サブコマンド | 機能 |
+|---|---|
+| `set <field> [--stdin]` | 対話的または stdin 経由で保管 |
+| `delete <field>` | 削除 |
+| `status` | 各エントリの「stored / not stored」のみを表示 (値は出さない) |
+| `migrate [--dry-run]` | credentials.toml の client_secret を Keychain に移し、toml から削除 |
+
+`get` サブコマンドは**意図的に提供しません**。理由は以下です。
+
+- 値を取り出す正当なユースケースが存在しません。動作確認は `status`
+  で十分です。バックアップは Falcon 側の UI で client_secret を再発行
+  するのが正攻法です。
+- AI エージェントが「デバッグのため」と称して `get` を実行し、出力が
+  会話履歴・ログ・PR 説明に流出する事故を構造的に防ぎます。
+- シェル履歴・端末スクロールバックへの汚染を防ぎます。
+
+### Migrate の安全策
+
+`migrate` は以下の順で実行します。
+
+1. credentials.toml から client_secret を抽出 (quoted basic string のみ
+   サポート、literal / multi-line は明示エラー)
+2. ユーザーに移行確認 (default No)
+3. **Keychain への書き込み** (toml 未変更のため失敗時の rollback 不要)
+4. ユーザーに plaintext 処分方法を確認:
+   - **default Yes**: tempfile + atomic rename で `client_secret` 行を
+     完全削除。disk 上に plaintext は残らない
+   - **No**: 0o600 backup を作成 + toml は新形式に書き換え + 多段の
+     警告を表示
+5. 失敗時は Keychain エントリを rollback し、plaintext がどこに残って
+   いるかを明示
+
+backup 作成は default ではなく opt-in です。backup を残す選択は意識的
+にしか取れず、取った場合は強い警告を出します。
+
+### Zeroize と tempfile による hardening
+
+- 対話入力・stdin 入力・migrate 時の toml 読取り内容・抽出した secret
+  は `zeroize::Zeroizing<String>` でラップし、scope を抜ける際に heap
+  上のバイト列をゼロ埋めします。swap out / core dump / panic backtrace
+  の窓を狭めます。
+- `atomic_replace` は `tempfile::NamedTempFile::new_in` を使い、予測
+  可能な tempfile 名を避けます。`persist()` が失敗すると `NamedTempFile`
+  は drop 時に自動で unlink されるため、手動 cleanup 経路を忘れるバグ
+  クラスが消えます。
+
+### Debug マスク
+
+`FalconCredentials` の `Debug` 実装を手動化し、`client_secret` を `***`
+でマスクします。`dbg!` / `{:?}` / panic backtrace 経由の偶発漏洩を
+防ぎます。
+
+### ローカル平文の取り扱い
+
+migrate で作成する backup ファイルは `OpenOptions::mode(0o600) +
+create_new(true)` で書き出します。`fs::copy` は元ファイルの mode を
+継承する (典型的には `0o644`) ため使いません。toml 本体の書き換えは
+sibling tempfile への書き込み + `rename(2)` でアトミックに行います。
+
+## 結果
+
+### Positive
+
+- `client_secret` がホームディレクトリのバックアップ・他プロセス・
+  dotfiles リポジトリから完全に隔離されます
+- macOS 標準の Keychain Access.app から GUI で監査・削除可能です
+- trait 抽象化により Linux / Windows backend の追加コストが小さい
+  です
+- 既存 toml ユーザーは何もせずアップグレードしても挙動が変わらず、
+  `migrate` で能動的に移行できます
+- OSStatus 判定により locale 非依存で Unavailable / Backend を分類
+  できます
+
+### Negative
+
+- 初回アクセスと `cargo install` 再ビルドのたびに Keychain ACL
+  ダイアログが出ます。これは macOS の codesign ベース ACL に由来する
+  挙動で、Homebrew bottle のような署名安定なバイナリ配布で緩和でき
+  ます
+- `keyring` crate の追加でサプライチェーン面積が増えます。`cargo deny`
+  での監視を継続します
+- 環境変数優先のため、CI や開発環境で `FALCON_CLIENT_SECRET` を
+  誤って export したままのセッションでは Keychain 値が使われません。
+  これは想定仕様で、ユーザー側で `unset FALCON_CLIENT_SECRET` する
+  必要があります
+
+## 代替案
+
+### A. `security` コマンドのサブプロセス呼び出し
+
+`/usr/bin/security add-generic-password` を `Command` で叩く方式です。
+追加 crate は不要ですが、子プロセス起動コスト・シェルエスケープ・
+ACL の細かい制御が課題です。`keyring` crate は `Security.framework` を
+直接 FFI で呼ぶため、子プロセス不要・型安全です。
+
+### B. `security-framework` crate を直接利用
+
+最低レベルです。ACL を細かく制御できますが、コード量が増え、Linux /
+Windows backend を将来追加する際に再抽象化が必要です。`keyring` crate
+は最初から cross-platform 抽象化を持っています (ただし
+`classify_keyring_err` では `security-framework` の `Error::code()` を
+直接参照します)。
+
+### C. client_id / member_cid も Keychain に格納
+
+これらは機密性が低く (公開可能な識別子)、Keychain に入れると ACL
+ダイアログ頻度が増えるだけで便益が小さいため不採用としました。
+toml / env / CLI args に残します。
+
+### D. backup を default で作成し続ける
+
+backup ファイル自体が plaintext を持つため移行の意図を裏切ります。
+「default は完全削除、backup は opt-in」に変更済みです。
+
+## 先行事例
+
+- **mde-cli ADR-0004**: 同じパターンを Microsoft Defender CLI 向けに
+  先行実装
+- **ssh-agent / gpg-agent**: 秘密鍵をプロセスメモリに保持する方式
+  (falcon-cli ADR-0001 で採用済)
+- **`gh` CLI**: Keychain / Secret Service / Credential Manager を抽象化
+  して OAuth トークンを保管
+- **Docker CLI**: `docker-credential-osxkeychain` 等の credential
+  helper を介して registry credentials を Keychain に保管
+
+## 影響範囲
+
+- `Cargo.toml` — `keyring`, `security-framework = "3"`, `zeroize`,
+  `tempfile`, `rpassword` を追加
+- `src/config/credential_store.rs` — trait と KeychainStore 実装
+- `src/config/mod.rs` — `FalconCredentials::resolve()` の優先順位拡張、
+  `Debug` の手動マスク化、`ENV_LOCK` による test 逐次化
+- `src/cli.rs` — `Command::Credentials` variant + `CredentialsCommand`
+  / `CredentialField` 定義
+- `src/commands/credentials.rs` — handler 実装 (set / delete / status /
+  migrate)
+- `src/main.rs` — `credentials` サブコマンドで resolve をスキップ
+- `src/dispatch.rs` — `Credentials` の stub arm 追加
+- `src/error.rs` — `FalconError::InvalidInput(String)` variant 追加
+- `README.md` — Credential storage セクション追加
+
+## セキュリティ考慮事項
+
+- **codesign の安定性**: `cargo install` で再ビルドするたびに ACL が
+  再評価され、ダイアログが再出します。本質的な解決には Homebrew bottle
+  のような署名済みバイナリ配布が必要です
+- **`FALCON_CLIENT_SECRET` 環境変数の優先**: ユーザーが明示的に export
+  した場合は Keychain より優先されます。CI ランナーを奪取された場合
+  等の env 経由の攻撃は Keychain では防げません
+- **Keychain メモリダンプ**: root 権限による Keychain unlock 後の
+  メモリスキャンは ADR-0002 (agent の hardening) の延長で緩和し、
+  本 ADR のスコープ外とします
+- **`keyring::Error` の OSStatus 判定**: `keyring` の major upgrade で
+  `PlatformFailure` のラッピング形状が変わる可能性があります。downcast
+  が失敗した場合に備え、文字列マッチを last-resort fallback として
+  残しています

--- a/src/agent/handler.rs
+++ b/src/agent/handler.rs
@@ -189,5 +189,6 @@ fn classify_error(err: &crate::error::FalconError) -> (String, String) {
             ("json".to_string(), "response parsing failed".to_string())
         }
         crate::error::FalconError::Config(msg) => ("config".to_string(), msg.clone()),
+        crate::error::FalconError::InvalidInput(msg) => ("invalid_input".to_string(), msg.clone()),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -838,6 +838,27 @@ pub enum Command {
         action: AgentAction,
     },
 
+    // ── Credentials ──
+    /// Manage stored credentials (macOS Keychain)
+    #[command(
+        next_help_heading = "Configuration",
+        subcommand_required = true,
+        arg_required_else_help = true,
+        hide = true,
+        long_about = "Manage stored credentials (macOS Keychain).\n\
+                      \n\
+                      Secrets are stored in the login keychain under \
+                      service=\"dev.falcon-cli\". Inspect or delete via \
+                      Keychain Access.app or `security \
+                      find-generic-password -s dev.falcon-cli`. See README \
+                      for the full credential resolution order and \
+                      migration steps."
+    )]
+    Credentials {
+        #[command(subcommand)]
+        action: CredentialsCommand,
+    },
+
     // ── Profile ──
     /// Manage command profiles
     #[command(next_help_heading = "Configuration")]
@@ -845,6 +866,53 @@ pub enum Command {
         #[command(subcommand)]
         action: ProfileAction,
     },
+}
+
+/// Subcommands under `falcon-cli credentials`.
+#[derive(Subcommand, Debug)]
+pub enum CredentialsCommand {
+    /// Store a credential in the OS credential store (e.g. macOS Keychain).
+    #[command(arg_required_else_help = true)]
+    Set {
+        #[arg(value_enum)]
+        field: CredentialField,
+        /// Read the value from stdin instead of prompting interactively.
+        /// Useful for CI / automation. The value must be a single line.
+        #[arg(long)]
+        stdin: bool,
+    },
+    /// Delete a credential from the OS credential store.
+    #[command(arg_required_else_help = true)]
+    Delete {
+        #[arg(value_enum)]
+        field: CredentialField,
+    },
+    /// Show whether each credential is stored. Values are never printed.
+    Status,
+    /// Migrate `client_secret` from credentials.toml into the OS credential store.
+    Migrate {
+        /// Show what would be done without modifying anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Credential fields supported by `falcon-cli credentials`.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum CredentialField {
+    /// OAuth2 client secret. Sensitive — stored only in the credential store.
+    ClientSecret,
+}
+
+impl CredentialField {
+    /// The logical key under which this field is stored in the credential
+    /// store. Returns a static identifier (e.g. "client_secret") — never
+    /// the credential value.
+    pub fn key(self) -> &'static str {
+        match self {
+            CredentialField::ClientSecret => crate::config::credential_store::KEY_CLIENT_SECRET,
+        }
+    }
 }
 
 /// Profile subcommand actions.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ Agent:
   agent
 
 Configuration:
-  profile
+  credentials, profile
 ";
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -844,7 +844,6 @@ pub enum Command {
         next_help_heading = "Configuration",
         subcommand_required = true,
         arg_required_else_help = true,
-        hide = true,
         long_about = "Manage stored credentials (macOS Keychain).\n\
                       \n\
                       Secrets are stored in the login keychain under \

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -1,0 +1,605 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use zeroize::Zeroizing;
+
+use crate::cli::{CredentialField, CredentialsCommand};
+use crate::config::credential_store::{default_store, CredentialStore, KEY_CLIENT_SECRET};
+use crate::error::FalconError;
+
+/// File mode for any artifact that may contain plaintext credentials.
+const SECRET_FILE_MODE: u32 = 0o600;
+
+pub fn handle(cmd: &CredentialsCommand) -> Result<(), FalconError> {
+    let store = default_store().ok_or_else(|| {
+        FalconError::Config(
+            "no credential store backend available on this platform (macOS Keychain required)"
+                .to_string(),
+        )
+    })?;
+
+    match cmd {
+        CredentialsCommand::Set { field, stdin } => set_value(store.as_ref(), *field, *stdin),
+        CredentialsCommand::Delete { field } => delete_value(store.as_ref(), *field),
+        CredentialsCommand::Status => print_status(store.as_ref()),
+        CredentialsCommand::Migrate { dry_run } => migrate(store.as_ref(), *dry_run),
+    }
+}
+
+fn set_value(
+    store: &dyn CredentialStore,
+    field: CredentialField,
+    from_stdin: bool,
+) -> Result<(), FalconError> {
+    // Wrap the secret in Zeroizing so the heap allocation is wiped on
+    // drop. This narrows the window where a swap-out, core dump, or
+    // panic-time backtrace could expose the value. The buffer used to
+    // read stdin is also zeroized for the same reason.
+    let value: Zeroizing<String> = if from_stdin {
+        let mut buf: Zeroizing<String> = Zeroizing::new(String::new());
+        io::stdin()
+            .read_line(&mut buf)
+            .map_err(|e| FalconError::Config(format!("failed to read stdin: {}", e)))?;
+        // Trim full whitespace (not just CRLF) so a stray trailing space
+        // pasted from a password manager does not silently corrupt the secret.
+        let trimmed = Zeroizing::new(buf.trim().to_string());
+        if trimmed.is_empty() {
+            return Err(FalconError::InvalidInput(
+                "empty value from stdin".to_string(),
+            ));
+        }
+        trimmed
+    } else {
+        let prompt = format!("Enter {} (input hidden): ", field.key());
+        Zeroizing::new(
+            rpassword::prompt_password(prompt)
+                .map_err(|e| FalconError::Config(format!("failed to read password: {}", e)))?,
+        )
+    };
+
+    if value.is_empty() {
+        return Err(FalconError::InvalidInput("empty value".to_string()));
+    }
+
+    store
+        .set(field.key(), &value)
+        .map_err(|e| FalconError::Config(e.to_string()))?;
+    println!("Stored {} in credential store", field.key());
+    println!("Verify with: falcon-cli credentials status");
+    Ok(())
+}
+
+fn delete_value(store: &dyn CredentialStore, field: CredentialField) -> Result<(), FalconError> {
+    store
+        .delete(field.key())
+        .map_err(|e| FalconError::Config(e.to_string()))?;
+    println!("Deleted {} from credential store", field.key());
+    Ok(())
+}
+
+fn print_status(store: &dyn CredentialStore) -> Result<(), FalconError> {
+    // Probe each known field. We print only the field's static key (e.g.
+    // "client_secret") and a presence flag — never the credential value.
+    let keys = [KEY_CLIENT_SECRET];
+    println!("Credential store: macOS Keychain (service=dev.falcon-cli)");
+    let mut saw_error = false;
+    for key in keys {
+        match store.get(key) {
+            Ok(Some(_)) => println!("  {} : stored", key),
+            Ok(None) => println!("  {} : not stored", key),
+            Err(e) => {
+                println!("  {} : error ({})", key, e);
+                saw_error = true;
+            }
+        }
+    }
+    if saw_error {
+        println!();
+        println!(
+            "One or more entries could not be accessed. This usually means a \
+             Keychain ACL change (often triggered by a `cargo install` rebuild \
+             that changed the binary's code signature). See the README section \
+             \"Credential storage\" -> \"Notes on Keychain prompts\" for how to \
+             re-grant access via Keychain Access.app."
+        );
+    }
+    Ok(())
+}
+
+fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), FalconError> {
+    let path = find_credentials_toml().ok_or_else(|| {
+        FalconError::Config(
+            "no credentials.toml found to migrate from. \
+             To store a secret directly in the Keychain, run: \
+             falcon-cli credentials set client-secret"
+                .to_string(),
+        )
+    })?;
+    // Resolve to canonical path so the user sees what we will actually
+    // mutate, not a relative path that could be interpreted as something
+    // surprising (e.g. `.falcon-credentials.toml` in cwd).
+    let canonical = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    println!("Found credentials.toml: {}", canonical.display());
+
+    // Read the toml into a Zeroizing buffer: it contains the plaintext
+    // secret we are about to migrate, and we want every copy of those
+    // bytes wiped before this scope returns.
+    let original: Zeroizing<String> = Zeroizing::new(fs::read_to_string(&path).map_err(|e| {
+        FalconError::Config(format!("failed to read {}: {}", canonical.display(), e))
+    })?);
+
+    let secret: Zeroizing<String> = match extract_client_secret(&original) {
+        SecretScan::Present(s) => Zeroizing::new(s),
+        SecretScan::Absent => {
+            println!("  client_secret: not present (nothing to migrate)");
+            println!();
+            println!(
+                "If you want to store a secret in the Keychain anyway, run: \
+                 falcon-cli credentials set client-secret"
+            );
+            return Ok(());
+        }
+        SecretScan::Unsupported(form) => {
+            return Err(FalconError::Config(format!(
+                "client_secret uses an unsupported quoting form ({}); refusing to rewrite. \
+                 Convert it to `client_secret = \"...\"` form and retry.",
+                form
+            )));
+        }
+    };
+    println!("  client_secret: present (will move to credential store)");
+
+    if dry_run {
+        println!("(dry-run) no changes made");
+        return Ok(());
+    }
+
+    // Step 1: confirm the migration itself. Echo the canonical path again
+    // so a hostile cwd cannot smuggle in a different file between the find
+    // and the prompt.
+    if !prompt_yes_no(
+        &format!(
+            "Migrate client_secret from {} to the credential store?",
+            canonical.display()
+        ),
+        false,
+    )? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    // Step 2: write to the credential store first. We have not touched the
+    // toml yet, so any failure here leaves the user in their pre-migration
+    // state with no rollback needed.
+    store
+        .set(KEY_CLIENT_SECRET, &secret)
+        .map_err(|e| FalconError::Config(format!("credential store: {}", e)))?;
+    println!("Stored client_secret in credential store");
+
+    // Step 3: ask how to dispose of the plaintext copy. The default is the
+    // safest option — fully remove it. Keeping a backup leaves a 0o600
+    // copy on disk that the user has to remember to delete; we surface
+    // that risk loudly when they choose to keep it.
+    let mode = prompt_disposal()?;
+    // `updated` is derived by removing the secret line from `original`, so
+    // it does not contain the secret. Plain String is fine.
+    let updated = remove_client_secret_line(&original);
+
+    match mode {
+        DisposalMode::Remove => {
+            if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
+                rollback_and_fail(store, &canonical, &e.to_string(), None)?;
+            }
+            println!("Removed client_secret line from {}", canonical.display());
+            println!();
+            println!("Done. The plaintext secret no longer exists on disk.");
+        }
+        DisposalMode::KeepBackup => {
+            // Create the backup BEFORE rewriting the original, so a failure
+            // partway through still leaves something recoverable. 0o600 +
+            // create_new ensures the backup is private and never clobbers
+            // an older one.
+            let backup = backup_path(&path);
+            if let Err(e) = write_secret_file(&backup, original.as_bytes(), true) {
+                rollback_and_fail(store, &canonical, &format!("{}", e), None)?;
+            }
+            if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
+                // Try to remove the backup we just wrote, then roll back
+                // Keychain. The original toml is untouched.
+                let _ = fs::remove_file(&backup);
+                rollback_and_fail(store, &canonical, &e.to_string(), None)?;
+            }
+            println!(
+                "Removed client_secret line from {} (backup at {})",
+                canonical.display(),
+                backup.display()
+            );
+            println!();
+            println!(
+                "WARNING: {} still contains the plaintext client_secret.",
+                backup.display()
+            );
+            println!(
+                "WARNING: This file defeats the purpose of moving the secret to the Keychain."
+            );
+            println!("WARNING: Delete it as soon as you have confirmed the new setup works:");
+            println!("       rm {}", backup.display());
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum DisposalMode {
+    /// Remove the `client_secret` line outright; no plaintext copy remains.
+    Remove,
+    /// Keep a 0o600 backup of the original toml alongside the rewritten file.
+    KeepBackup,
+}
+
+/// Ask the user a yes/no question and return the parsed answer.
+/// `default_yes` controls what an empty (just-Enter) response means.
+fn prompt_yes_no(question: &str, default_yes: bool) -> Result<bool, FalconError> {
+    let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
+    print!("{} {}: ", question, suffix);
+    io::stdout()
+        .flush()
+        .map_err(|e| FalconError::Config(format!("flush stdout: {}", e)))?;
+    let mut answer = String::new();
+    io::stdin()
+        .read_line(&mut answer)
+        .map_err(|e| FalconError::Config(format!("read stdin: {}", e)))?;
+    Ok(match answer.trim() {
+        "" => default_yes,
+        s => matches!(s, "y" | "Y" | "yes" | "Yes" | "YES"),
+    })
+}
+
+/// Ask the user how to dispose of the plaintext copy of `client_secret`
+/// after a successful Keychain write. Default is `Remove` — the safest
+/// option, since any copy left on disk re-introduces the risk we just
+/// migrated away from.
+fn prompt_disposal() -> Result<DisposalMode, FalconError> {
+    if prompt_yes_no(
+        "Remove the plaintext client_secret line from credentials.toml? \
+         (Recommended. Choosing 'no' keeps a 0600 backup of the original on disk.)",
+        true,
+    )? {
+        Ok(DisposalMode::Remove)
+    } else {
+        Ok(DisposalMode::KeepBackup)
+    }
+}
+
+/// Helper used when an atomic_replace / backup-write step fails after we
+/// have already written to the credential store. Rolls the Keychain entry
+/// back and returns a fully-formatted FalconError so the call site can
+/// short-circuit with `?`.
+fn rollback_and_fail(
+    store: &dyn CredentialStore,
+    canonical: &Path,
+    cause: &str,
+    backup: Option<&Path>,
+) -> Result<(), FalconError> {
+    let rb = store.delete(KEY_CLIENT_SECRET);
+    let rb_msg = match rb {
+        Ok(()) => "credential store entry rolled back".to_string(),
+        Err(re) => format!(
+            "WARNING: failed to roll back credential store entry: {}",
+            re
+        ),
+    };
+    let extra = match backup {
+        Some(p) => format!(" Backup at {} also contains the plaintext.", p.display()),
+        None => String::new(),
+    };
+    Err(FalconError::Config(format!(
+        "failed to update {}: {}. {}. The plaintext secret is still in {}.{}",
+        canonical.display(),
+        cause,
+        rb_msg,
+        canonical.display(),
+        extra,
+    )))
+}
+
+/// Write `bytes` to `path` with mode 0o600. When `exclusive` is true, fails
+/// if the path already exists — used for backups so we never clobber an
+/// older backup that the user might still need.
+fn write_secret_file(path: &Path, bytes: &[u8], exclusive: bool) -> Result<(), FalconError> {
+    let mut opts = OpenOptions::new();
+    opts.write(true).mode(SECRET_FILE_MODE);
+    if exclusive {
+        opts.create_new(true);
+    } else {
+        opts.create(true).truncate(true);
+    }
+    let mut f: File = opts
+        .open(path)
+        .map_err(|e| FalconError::Config(format!("open {}: {}", path.display(), e)))?;
+    f.write_all(bytes)
+        .map_err(|e| FalconError::Config(format!("write {}: {}", path.display(), e)))?;
+    // Belt and suspenders: explicitly set mode in case the FS ignored the
+    // open-time mode (some networked filesystems do).
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(SECRET_FILE_MODE));
+    Ok(())
+}
+
+/// Replace `path` with `bytes` atomically via `tempfile::NamedTempFile::new_in`.
+///
+/// Using `tempfile` rather than a unix-nanos suffix gives us a random
+/// tempfile name (immune to predictable-name races in shared dirs) and
+/// auto-cleanup if persist() fails — no manual cleanup path to forget
+/// about. The final file's mode is 0o600, which is at least as
+/// restrictive as any sane prior mode.
+fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".falcon-cred-")
+        .suffix(".tmp")
+        .permissions(fs::Permissions::from_mode(SECRET_FILE_MODE))
+        .tempfile_in(dir)?;
+    tmp.write_all(bytes)?;
+    tmp.as_file().sync_all().ok();
+    // persist() consumes the NamedTempFile; on success the file lives at
+    // `path`. On failure the NamedTempFile is returned inside the error
+    // and dropped, which unlinks it.
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+fn find_credentials_toml() -> Option<PathBuf> {
+    let candidates = credentials_search_paths();
+    candidates.into_iter().find(|p| p.is_file())
+}
+
+fn credentials_search_paths() -> Vec<PathBuf> {
+    let mut paths = vec![PathBuf::from(".falcon-credentials.toml")];
+    if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
+        paths.push(
+            PathBuf::from(config_home)
+                .join("falcon-cli")
+                .join("credentials.toml"),
+        );
+    } else if let Ok(home) = std::env::var("HOME") {
+        paths.push(
+            PathBuf::from(home)
+                .join(".config")
+                .join("falcon-cli")
+                .join("credentials.toml"),
+        );
+    }
+    paths
+}
+
+fn backup_path(p: &Path) -> PathBuf {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut name = p.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".bak.{}", ts));
+    p.with_file_name(name)
+}
+
+/// Outcome of scanning a credentials.toml for `client_secret`.
+#[derive(Debug, PartialEq, Eq)]
+enum SecretScan {
+    /// Field is absent or set to an empty basic string.
+    Absent,
+    /// Field is present and stored as `client_secret = "..."` (single-line basic).
+    Present(String),
+    /// Field is present but uses a quoting form we refuse to rewrite
+    /// (literal strings, multi-line basic, multi-line literal). We bail out
+    /// rather than risk a partial migration where extract returns None but
+    /// blank_client_secret would still wipe the line.
+    Unsupported(&'static str),
+}
+
+/// Scan a credentials.toml line-by-line for `client_secret`. We avoid a full
+/// TOML round-trip so the user's formatting and comments survive rewrite.
+fn extract_client_secret(content: &str) -> SecretScan {
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        // Word-boundary match: rule out `client_secret_extra` etc.
+        let Some(rest) = trimmed.strip_prefix("client_secret") else {
+            continue;
+        };
+        let after_key = rest.trim_start();
+        if !after_key.starts_with('=') {
+            continue;
+        }
+        let value_part = after_key[1..].trim_start();
+
+        if value_part.starts_with("\"\"\"") {
+            return SecretScan::Unsupported("multi-line basic string (\"\"\"...\"\"\")");
+        }
+        if value_part.starts_with("'''") {
+            return SecretScan::Unsupported("multi-line literal string ('''...''')");
+        }
+        if value_part.starts_with('\'') {
+            return SecretScan::Unsupported("literal string ('...')");
+        }
+        if let Some(rest) = value_part.strip_prefix('"') {
+            // Find the closing quote. Reject embedded escaped quotes for now
+            // (TOML allows `\"`); they are not produced by typical templates,
+            // and refusing them is safer than a half-correct parse.
+            if rest.contains("\\\"") {
+                return SecretScan::Unsupported("basic string with escaped quotes");
+            }
+            return match rest.find('"') {
+                Some(0) => SecretScan::Absent,
+                Some(end) => SecretScan::Present(rest[..end].to_string()),
+                None => SecretScan::Unsupported("unterminated basic string"),
+            };
+        }
+        return SecretScan::Unsupported("unrecognized value form");
+    }
+    SecretScan::Absent
+}
+
+/// Remove the `client_secret = "..."` line entirely while preserving the
+/// rest of the file (comments, ordering, other fields). Only a true
+/// `client_secret` key is matched — `client_secret_extra` and similar are
+/// left untouched.
+///
+/// We delete the line rather than blanking the value because a blanked
+/// `client_secret = ""` is itself a footgun: a future reader might think
+/// the empty string is an intentional override and wonder where the real
+/// value lives. A missing key makes the toml's role as "non-secret config"
+/// unambiguous.
+fn remove_client_secret_line(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("client_secret") {
+            let after = rest.trim_start();
+            if after.starts_with('=') {
+                continue;
+            }
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_quoted_value() {
+        let s = r#"
+[credentials]
+client_id = "c"
+client_secret = "abc123"
+base_url = "https://api.crowdstrike.com"
+"#;
+        assert_eq!(
+            extract_client_secret(s),
+            SecretScan::Present("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_returns_absent_when_missing() {
+        let s = r#"
+[credentials]
+client_id = "c"
+"#;
+        assert_eq!(extract_client_secret(s), SecretScan::Absent);
+    }
+
+    #[test]
+    fn extract_returns_absent_for_empty_basic_string() {
+        let s = "client_secret = \"\"\n";
+        assert_eq!(extract_client_secret(s), SecretScan::Absent);
+    }
+
+    #[test]
+    fn extract_rejects_literal_string() {
+        let s = "client_secret = 'abc'\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_rejects_multiline_basic() {
+        let s = "client_secret = \"\"\"abc\"\"\"\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_rejects_multiline_literal() {
+        let s = "client_secret = '''abc'''\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_ignores_similarly_named_keys() {
+        let s = "client_secret_extra = \"x\"\n";
+        assert_eq!(extract_client_secret(s), SecretScan::Absent);
+    }
+
+    #[test]
+    fn remove_drops_only_client_secret_line() {
+        let s = r#"# comment
+[credentials]
+client_id = "c"
+client_secret = "abc123"
+base_url = "https://api.crowdstrike.com"
+"#;
+        let out = remove_client_secret_line(s);
+        // Don't include `out` in the assert message: CodeQL flags
+        // formatting a function-of-secret-shaped-input into a diagnostic
+        // string, even though this is a test fixture.
+        assert!(!out.contains("client_secret"));
+        assert!(!out.contains("abc123"));
+        assert!(out.contains("# comment"));
+        assert!(out.contains("client_id = \"c\""));
+        assert!(out.contains("base_url"));
+    }
+
+    #[test]
+    fn remove_works_with_indented_key() {
+        let s = "  client_secret = \"x\"\nother = 1\n";
+        let out = remove_client_secret_line(s);
+        assert_eq!(out, "other = 1\n");
+    }
+
+    #[test]
+    fn remove_does_not_touch_similarly_named_keys() {
+        let s = "client_secret_extra = \"x\"\n";
+        let out = remove_client_secret_line(s);
+        assert_eq!(out, "client_secret_extra = \"x\"\n");
+    }
+
+    #[test]
+    fn atomic_replace_writes_with_mode_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("creds.toml");
+        std::fs::write(&path, "old\n").unwrap();
+        // Make the original world-readable to prove atomic_replace tightens it.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        atomic_replace(&path, b"new\n").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new\n");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "atomic_replace must produce 0600, got {:o}",
+            mode
+        );
+    }
+
+    #[test]
+    fn write_secret_file_creates_0600() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("backup");
+        write_secret_file(&path, b"secret\n", true).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn write_secret_file_exclusive_refuses_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("backup");
+        std::fs::write(&path, b"existing").unwrap();
+        let err = write_secret_file(&path, b"new", true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("open"), "unexpected error: {}", msg);
+    }
+}

--- a/src/commands/credentials.rs
+++ b/src/commands/credentials.rs
@@ -191,7 +191,7 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), FalconError
     match mode {
         DisposalMode::Remove => {
             if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
-                rollback_and_fail(store, &canonical, &e.to_string(), None)?;
+                rollback_and_fail(store, &canonical, &e.to_string())?;
             }
             println!("Removed client_secret line from {}", canonical.display());
             println!();
@@ -204,13 +204,13 @@ fn migrate(store: &dyn CredentialStore, dry_run: bool) -> Result<(), FalconError
             // an older one.
             let backup = backup_path(&path);
             if let Err(e) = write_secret_file(&backup, original.as_bytes(), true) {
-                rollback_and_fail(store, &canonical, &format!("{}", e), None)?;
+                rollback_and_fail(store, &canonical, &format!("{}", e))?;
             }
             if let Err(e) = atomic_replace(&path, updated.as_bytes()) {
                 // Try to remove the backup we just wrote, then roll back
                 // Keychain. The original toml is untouched.
                 let _ = fs::remove_file(&backup);
-                rollback_and_fail(store, &canonical, &e.to_string(), None)?;
+                rollback_and_fail(store, &canonical, &e.to_string())?;
             }
             println!(
                 "Removed client_secret line from {} (backup at {})",
@@ -279,11 +279,15 @@ fn prompt_disposal() -> Result<DisposalMode, FalconError> {
 /// have already written to the credential store. Rolls the Keychain entry
 /// back and returns a fully-formatted FalconError so the call site can
 /// short-circuit with `?`.
+///
+/// Call sites always delete any backup file they created before invoking
+/// rollback_and_fail, so there is no leftover backup path to surface —
+/// the plaintext location to advertise to the user is always the
+/// canonical toml path.
 fn rollback_and_fail(
     store: &dyn CredentialStore,
     canonical: &Path,
     cause: &str,
-    backup: Option<&Path>,
 ) -> Result<(), FalconError> {
     let rb = store.delete(KEY_CLIENT_SECRET);
     let rb_msg = match rb {
@@ -293,17 +297,12 @@ fn rollback_and_fail(
             re
         ),
     };
-    let extra = match backup {
-        Some(p) => format!(" Backup at {} also contains the plaintext.", p.display()),
-        None => String::new(),
-    };
     Err(FalconError::Config(format!(
-        "failed to update {}: {}. {}. The plaintext secret is still in {}.{}",
+        "failed to update {}: {}. {}. The plaintext secret is still in {}.",
         canonical.display(),
         cause,
         rb_msg,
         canonical.display(),
-        extra,
     )))
 }
 
@@ -353,27 +352,12 @@ fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 fn find_credentials_toml() -> Option<PathBuf> {
-    let candidates = credentials_search_paths();
-    candidates.into_iter().find(|p| p.is_file())
-}
-
-fn credentials_search_paths() -> Vec<PathBuf> {
-    let mut paths = vec![PathBuf::from(".falcon-credentials.toml")];
-    if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
-        paths.push(
-            PathBuf::from(config_home)
-                .join("falcon-cli")
-                .join("credentials.toml"),
-        );
-    } else if let Ok(home) = std::env::var("HOME") {
-        paths.push(
-            PathBuf::from(home)
-                .join(".config")
-                .join("falcon-cli")
-                .join("credentials.toml"),
-        );
-    }
-    paths
+    // Delegate to the shared resolver in `config` so the migrate target
+    // and the resolve target cannot drift apart if the search paths are
+    // ever extended.
+    crate::config::credentials_search_paths()
+        .into_iter()
+        .find(|p| p.is_file())
 }
 
 fn backup_path(p: &Path) -> PathBuf {
@@ -452,6 +436,14 @@ fn extract_client_secret(content: &str) -> SecretScan {
 /// the empty string is an intentional override and wonder where the real
 /// value lives. A missing key makes the toml's role as "non-secret config"
 /// unambiguous.
+///
+/// INVARIANT: this function assumes `content` has already been vetted by
+/// `extract_client_secret` returning `SecretScan::Present(_)` — i.e. the
+/// `client_secret` value is a single-line basic string. If a future
+/// refactor ever calls `remove_client_secret_line` on a literal-string
+/// or multi-line value, it would silently strip the opening line and
+/// leave the rest dangling. Keep the `Unsupported` bail-out in migrate
+/// as the guard.
 fn remove_client_secret_line(content: &str) -> String {
     let mut out = String::with_capacity(content.len());
     for line in content.lines() {
@@ -532,6 +524,39 @@ client_id = "c"
     fn extract_ignores_similarly_named_keys() {
         let s = "client_secret_extra = \"x\"\n";
         assert_eq!(extract_client_secret(s), SecretScan::Absent);
+    }
+
+    #[test]
+    fn extract_rejects_unterminated_basic_string() {
+        // Missing closing quote: we refuse rather than eat the rest of the
+        // file as if it were the value.
+        let s = "client_secret = \"abc\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_rejects_escaped_quote_in_basic_string() {
+        // TOML allows `\"` inside basic strings, but we refuse those to
+        // avoid a half-correct parse that could truncate the secret at
+        // the first `"`.
+        let s = "client_secret = \"a\\\"b\"\n";
+        assert!(matches!(
+            extract_client_secret(s),
+            SecretScan::Unsupported(_)
+        ));
+    }
+
+    #[test]
+    fn extract_accepts_extra_whitespace_around_equals() {
+        // `key = value` with multiple spaces should still parse cleanly.
+        let s = "client_secret   =   \"abc\"\n";
+        assert_eq!(
+            extract_client_secret(s),
+            SecretScan::Present("abc".to_string())
+        );
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub mod container_vulnerabilities;
 pub mod content_update_policies;
 pub mod correlation_rules;
 pub mod correlation_rules_admin;
+pub mod credentials;
 pub mod cspm_registration;
 pub mod custom_ioa;
 pub mod custom_storage;

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -207,6 +207,27 @@ pub mod test_support {
             Ok(())
         }
     }
+
+    /// `CredentialStore` whose `get` always returns `StoreError::Backend`.
+    /// Used to exercise the resolve path that must *not* fall through to
+    /// `credentials.toml` when the Keychain itself reports an access
+    /// failure (denied prompt, daemon down, ACL mismatch) — silently
+    /// picking up a stale plaintext secret would defeat the migration.
+    pub struct FailingStore;
+
+    impl CredentialStore for FailingStore {
+        fn get(&self, _key: &str) -> Result<Option<String>, StoreError> {
+            Err(StoreError::Backend("simulated backend failure".to_string()))
+        }
+
+        fn set(&self, _key: &str, _value: &str) -> Result<(), StoreError> {
+            Err(StoreError::Backend("simulated backend failure".to_string()))
+        }
+
+        fn delete(&self, _key: &str) -> Result<(), StoreError> {
+            Err(StoreError::Backend("simulated backend failure".to_string()))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -2,6 +2,9 @@ use std::fmt;
 
 /// Service identifier used as the Keychain "service" attribute.
 /// Acts as a namespace so credentials do not collide with other apps.
+/// Only consumed by the macOS `KeychainStore` — on non-macOS builds
+/// there is no backend, so suppress the resulting dead-code warning.
+#[cfg(target_os = "macos")]
 pub const SERVICE: &str = "dev.falcon-cli";
 
 /// Logical identifier for the OAuth2 client_secret entry. This is the
@@ -9,6 +12,11 @@ pub const SERVICE: &str = "dev.falcon-cli";
 /// secret value itself.
 pub const KEY_CLIENT_SECRET: &str = "client_secret";
 
+/// On non-macOS builds the variants below are never constructed
+/// (there is no backend that would produce them). The trait still has
+/// to keep the type so the `read_secret_from_store` match is exhaustive
+/// on every target, hence the conditional allow.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[derive(Debug)]
 pub enum StoreError {
     /// The backend (e.g. Keychain) is not available on this platform.

--- a/src/config/credential_store.rs
+++ b/src/config/credential_store.rs
@@ -1,0 +1,261 @@
+use std::fmt;
+
+/// Service identifier used as the Keychain "service" attribute.
+/// Acts as a namespace so credentials do not collide with other apps.
+pub const SERVICE: &str = "dev.falcon-cli";
+
+/// Logical identifier for the OAuth2 client_secret entry. This is the
+/// label / key used to look the entry up in the store; it is NOT the
+/// secret value itself.
+pub const KEY_CLIENT_SECRET: &str = "client_secret";
+
+#[derive(Debug)]
+pub enum StoreError {
+    /// The backend (e.g. Keychain) is not available on this platform.
+    Unavailable(String),
+    /// An I/O or backend error occurred while accessing the store.
+    Backend(String),
+}
+
+impl fmt::Display for StoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StoreError::Unavailable(s) => write!(f, "credential store unavailable: {}", s),
+            StoreError::Backend(s) => write!(f, "credential store error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// Abstract storage backend for sensitive credentials.
+///
+/// `key` is the entry's identifier (e.g. "client_secret"), not the
+/// credential value. `get` returns `Ok(None)` when the entry simply does
+/// not exist (a normal state during fallback to the next source).
+/// Backend-level failures must be surfaced as `Err` so callers can
+/// distinguish "not stored" from "store unreachable".
+pub trait CredentialStore {
+    fn get(&self, key: &str) -> Result<Option<String>, StoreError>;
+    fn set(&self, key: &str, value: &str) -> Result<(), StoreError>;
+    fn delete(&self, key: &str) -> Result<(), StoreError>;
+}
+
+#[cfg(target_os = "macos")]
+mod keychain {
+    use super::{CredentialStore, StoreError, SERVICE};
+    use keyring::Entry;
+
+    pub struct KeychainStore;
+
+    impl KeychainStore {
+        pub fn new() -> Self {
+            Self
+        }
+
+        fn entry(key: &str) -> Result<Entry, StoreError> {
+            // The Keychain API names the second slot "account"; we use our
+            // logical key as the account string.
+            Entry::new(SERVICE, key).map_err(|e| StoreError::Backend(e.to_string()))
+        }
+    }
+
+    impl Default for KeychainStore {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl CredentialStore for KeychainStore {
+        fn get(&self, key: &str) -> Result<Option<String>, StoreError> {
+            let entry = Self::entry(key)?;
+            match entry.get_password() {
+                Ok(v) => Ok(Some(v)),
+                Err(keyring::Error::NoEntry) => Ok(None),
+                Err(e) => Err(classify_keyring_err(e)),
+            }
+        }
+
+        fn set(&self, key: &str, value: &str) -> Result<(), StoreError> {
+            let entry = Self::entry(key)?;
+            entry.set_password(value).map_err(classify_keyring_err)
+        }
+
+        fn delete(&self, key: &str) -> Result<(), StoreError> {
+            let entry = Self::entry(key)?;
+            match entry.delete_credential() {
+                Ok(()) => Ok(()),
+                Err(keyring::Error::NoEntry) => Ok(()),
+                Err(e) => Err(classify_keyring_err(e)),
+            }
+        }
+    }
+
+    /// `errSecNoDefaultKeychain` from `Security.framework`.
+    /// See <https://developer.apple.com/documentation/security/errsecnodefaultkeychain>.
+    /// Locale-independent: the OSStatus is the same on every macOS install.
+    pub(super) const ERR_SEC_NO_DEFAULT_KEYCHAIN: i32 = -25307;
+    pub(super) const ERR_SEC_INVALID_KEYCHAIN: i32 = -25295;
+
+    /// Classify a `keyring::Error` into `Unavailable` (the store as a whole
+    /// is not present, e.g. CI sandbox without a default keychain) vs
+    /// `Backend` (an actual access failure that the user should investigate
+    /// — denied prompt, daemon down, ACL mismatch).
+    ///
+    /// We prefer to classify by OSStatus via downcasting the boxed source
+    /// of `keyring::Error::PlatformFailure` to `security_framework::base::Error`.
+    /// String-matching on the `Display` output is locale-translated on
+    /// Japanese / other macOS locales and would misclassify those users as
+    /// `Backend`, blocking the toml fallback on a clean machine. String
+    /// match survives only as a last-resort fallback.
+    pub(super) fn classify_keyring_err(e: keyring::Error) -> StoreError {
+        if let keyring::Error::PlatformFailure(ref src) = e {
+            // `keyring` boxes the platform error as `Box<dyn Error + Send + Sync>`.
+            // On macOS (apple-native backend) this is a `security_framework::base::Error`.
+            if let Some(sf) = src
+                .source()
+                .and_then(|s| s.downcast_ref::<security_framework::base::Error>())
+                .or_else(|| {
+                    // Some keyring paths box the sf error directly without wrapping.
+                    (src.as_ref() as &dyn std::error::Error)
+                        .downcast_ref::<security_framework::base::Error>()
+                })
+            {
+                let code = sf.code();
+                if code == ERR_SEC_NO_DEFAULT_KEYCHAIN || code == ERR_SEC_INVALID_KEYCHAIN {
+                    return StoreError::Unavailable(format!(
+                        "no default keychain (OSStatus {})",
+                        code
+                    ));
+                }
+                return StoreError::Backend(format!("OSStatus {}: {}", code, e));
+            }
+        }
+
+        // Last-resort: locale-dependent string match so the logic still
+        // works if the downcast above fails (e.g. keyring upgrades to a
+        // security-framework major that does not match our pinned one).
+        let msg = e.to_string();
+        let lower = msg.to_lowercase();
+        let unavailable = lower.contains("no default keychain")
+            || lower.contains("default keychain could not be found")
+            || lower.contains("no platform credential store");
+        if unavailable {
+            StoreError::Unavailable(msg)
+        } else {
+            StoreError::Backend(msg)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use keychain::KeychainStore;
+
+/// Returns the platform's default credential store, or `None` if no
+/// secure store backend is available on this build target.
+pub fn default_store() -> Option<Box<dyn CredentialStore>> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(Box::new(KeychainStore::new()))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::{CredentialStore, StoreError};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// In-memory `CredentialStore` used by tests.
+    pub struct MemoryStore {
+        inner: Mutex<HashMap<String, String>>,
+    }
+
+    impl MemoryStore {
+        pub fn new() -> Self {
+            Self {
+                inner: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl Default for MemoryStore {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl CredentialStore for MemoryStore {
+        fn get(&self, key: &str) -> Result<Option<String>, StoreError> {
+            Ok(self.inner.lock().unwrap().get(key).cloned())
+        }
+
+        fn set(&self, key: &str, value: &str) -> Result<(), StoreError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+
+        fn delete(&self, key: &str) -> Result<(), StoreError> {
+            self.inner.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::MemoryStore;
+    use super::*;
+
+    #[test]
+    fn memory_store_roundtrip() {
+        let s = MemoryStore::new();
+        assert!(s.get("k").unwrap().is_none());
+        s.set("k", "v").unwrap();
+        assert_eq!(s.get("k").unwrap().as_deref(), Some("v"));
+        s.delete("k").unwrap();
+        assert!(s.get("k").unwrap().is_none());
+    }
+
+    #[test]
+    fn memory_store_delete_missing_is_ok() {
+        let s = MemoryStore::new();
+        s.delete("missing").unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn classify_keyring_err_recognizes_no_default_keychain_by_osstatus() {
+        let sf_err =
+            security_framework::base::Error::from_code(keychain::ERR_SEC_NO_DEFAULT_KEYCHAIN);
+        let keyring_err = keyring::Error::PlatformFailure(Box::new(sf_err));
+        let classified = keychain::classify_keyring_err(keyring_err);
+        assert!(
+            matches!(classified, StoreError::Unavailable(_)),
+            "expected Unavailable, got {:?}",
+            classified
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn classify_keyring_err_treats_other_osstatus_as_backend() {
+        // -25300 = errSecItemNotFound, not a "no keychain at all" error —
+        // should be Backend so the user sees it.
+        let sf_err = security_framework::base::Error::from_code(-25300);
+        let keyring_err = keyring::Error::PlatformFailure(Box::new(sf_err));
+        let classified = keychain::classify_keyring_err(keyring_err);
+        assert!(
+            matches!(classified, StoreError::Backend(_)),
+            "expected Backend, got {:?}",
+            classified
+        );
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,7 +104,9 @@ fn read_secret_from_store(store: Option<&dyn CredentialStore>, key: &str) -> Sto
 }
 
 /// Search paths for credentials.toml (highest priority first).
-fn credentials_search_paths() -> Vec<PathBuf> {
+/// Shared with the `credentials migrate` subcommand so the migrate target
+/// and the resolve target cannot drift apart.
+pub(crate) fn credentials_search_paths() -> Vec<PathBuf> {
     let mut paths = vec![PathBuf::from(".falcon-credentials.toml")];
     if let Ok(config_home) = std::env::var("XDG_CONFIG_HOME") {
         paths.push(
@@ -594,5 +596,74 @@ client_secret = "toml-secret"
         // from clear_falcon_env prevents a user-level toml from being read.
         let creds = FalconCredentials::resolve_with_store(None, None, None, Some(&store));
         assert!(creds.client_secret.is_none());
+    }
+
+    /// Security-critical invariant: when the credential store itself
+    /// reports a backend error (Keychain prompt denied, daemon down,
+    /// ACL mismatch), `resolve_with_store` must NOT fall back to a
+    /// plaintext secret in `credentials.toml`. Silently picking up a
+    /// stale toml value would defeat the point of migrating to the
+    /// Keychain in the first place.
+    #[test]
+    fn test_resolve_with_store_backend_error_does_not_fall_back_to_toml() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_falcon_env() };
+
+        // Point XDG_CONFIG_HOME at a tempdir with a toml whose
+        // client_secret is populated — so we can prove it is *not* picked
+        // up when the store errors out.
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg_dir = tmp.path().join("falcon-cli");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        std::fs::write(
+            cfg_dir.join("credentials.toml"),
+            r#"
+[credentials]
+client_secret = "toml-secret-should-not-be-used"
+"#,
+        )
+        .unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+        let store = credential_store::test_support::FailingStore;
+        let creds = FalconCredentials::resolve_with_store(None, None, None, Some(&store));
+        assert!(
+            creds.client_secret.is_none(),
+            "Backend error must short-circuit to None, not fall back to toml. \
+             got: client_secret={:?}",
+            creds.client_secret.as_ref().map(|_| "<masked>"),
+        );
+
+        unsafe { clear_falcon_env() };
+    }
+
+    /// Sanity check: an `Unavailable` error DOES fall through to the toml
+    /// (non-macOS builds, CI sandbox without a default keychain, etc.),
+    /// so the migration story works on platforms where the Keychain is
+    /// simply not present. This exercises the complementary half of the
+    /// StoreLookup split.
+    #[test]
+    fn test_resolve_with_none_store_falls_through_to_toml() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_falcon_env() };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg_dir = tmp.path().join("falcon-cli");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        std::fs::write(
+            cfg_dir.join("credentials.toml"),
+            r#"
+[credentials]
+client_secret = "toml-secret"
+"#,
+        )
+        .unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", tmp.path()) };
+
+        // No store (simulates non-macOS `default_store() -> None`).
+        let creds = FalconCredentials::resolve_with_store(None, None, None, None);
+        assert_eq!(creds.client_secret.as_deref(), Some("toml-secret"));
+
+        unsafe { clear_falcon_env() };
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,10 @@ use std::path::PathBuf;
 
 use crate::error::{FalconError, Result};
 
+pub mod credential_store;
+
+use credential_store::{default_store, CredentialStore, StoreError, KEY_CLIENT_SECRET};
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub client_id: String,
@@ -27,15 +31,76 @@ struct CredentialsFile {
 }
 
 /// Resolved Falcon API credentials collected from CLI args, environment variables,
-/// and credentials.toml.
+/// the OS credential store (macOS Keychain), and credentials.toml.
 /// Once constructed, the process should call `FalconCredentials::clear_env()` to remove
 /// credential environment variables so that forked child processes do not inherit them.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct FalconCredentials {
     pub client_id: Option<String>,
     pub client_secret: Option<String>,
     pub base_url: String,
     pub member_cid: Option<String>,
+}
+
+/// Custom `Debug` impl that masks `client_secret` so that accidental `dbg!` /
+/// `{:?}` formatting cannot leak the secret into logs or error messages.
+impl std::fmt::Debug for FalconCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FalconCredentials")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &mask(&self.client_secret))
+            .field("base_url", &self.base_url)
+            .field("member_cid", &self.member_cid)
+            .finish()
+    }
+}
+
+fn mask(v: &Option<String>) -> &'static str {
+    match v {
+        Some(_) => "***",
+        None => "None",
+    }
+}
+
+/// Result of consulting the credential store for a secret.
+enum StoreLookup {
+    /// No store, or store backend not available (non-macOS build, etc.).
+    /// Caller should fall through to the next source.
+    SkipFallthrough,
+    /// Store reports the secret is not stored. Fall through to the next source.
+    NotStored,
+    /// Store returned the secret value.
+    Found(String),
+    /// Backend error (e.g. user denied the Keychain prompt, daemon down).
+    /// Caller MUST NOT fall through to credentials.toml — silently picking
+    /// up a stale plaintext secret would defeat the point of moving the
+    /// secret into the Keychain in the first place.
+    BackendError,
+}
+
+fn read_secret_from_store(store: Option<&dyn CredentialStore>, key: &str) -> StoreLookup {
+    let Some(store) = store else {
+        return StoreLookup::SkipFallthrough;
+    };
+    match store.get(key) {
+        Ok(Some(v)) => StoreLookup::Found(v),
+        Ok(None) => StoreLookup::NotStored,
+        Err(StoreError::Unavailable(msg)) => {
+            // `key` here is a static label like "client_secret", not the
+            // credential value. Log it for diagnostics.
+            eprintln!("warning: credential store unavailable for {}: {}", key, msg);
+            StoreLookup::SkipFallthrough
+        }
+        Err(StoreError::Backend(msg)) => {
+            eprintln!(
+                "error: credential store backend failure for {}: {}. \
+                 Refusing to fall back to credentials.toml — fix the store \
+                 access or unset the entry to make the toml fallback explicit.",
+                key, msg
+            );
+            StoreLookup::BackendError
+        }
+    }
 }
 
 /// Search paths for credentials.toml (highest priority first).
@@ -83,12 +148,38 @@ fn load_credentials_file() -> CredentialsFile {
 }
 
 impl FalconCredentials {
-    /// Resolve credentials from CLI args, environment variables, and credentials.toml.
-    /// Priority: CLI args > environment variables > credentials.toml > defaults.
+    /// Resolve credentials from CLI args, environment variables, the OS
+    /// credential store (macOS Keychain), and credentials.toml.
+    ///
+    /// Priority for `client_secret`:
+    ///   env var > Keychain > credentials.toml > None
+    /// Priority for `client_id` / `base_url` / `member_cid`:
+    ///   CLI args > env var > credentials.toml > defaults
+    ///
+    /// Keychain access may prompt the user (macOS) on first use. Backend
+    /// errors are reported on stderr and treated as "not stored" so we fall
+    /// through to the next source rather than aborting startup — except
+    /// that a Backend error explicitly *skips* the toml fallback, to avoid
+    /// silently picking up a stale plaintext secret.
     pub fn resolve(
         cli_client_id: Option<&str>,
         cli_base_url: Option<&str>,
         cli_member_cid: Option<&str>,
+    ) -> Self {
+        Self::resolve_with_store(
+            cli_client_id,
+            cli_base_url,
+            cli_member_cid,
+            default_store().as_deref(),
+        )
+    }
+
+    /// Like `resolve` but with an injectable credential store (used in tests).
+    pub fn resolve_with_store(
+        cli_client_id: Option<&str>,
+        cli_base_url: Option<&str>,
+        cli_member_cid: Option<&str>,
+        store: Option<&dyn CredentialStore>,
     ) -> Self {
         let file = load_credentials_file();
 
@@ -97,9 +188,17 @@ impl FalconCredentials {
             .or_else(|| std::env::var("FALCON_CLIENT_ID").ok())
             .or(file.client_id);
 
-        let client_secret = std::env::var("FALCON_CLIENT_SECRET")
-            .ok()
-            .or(file.client_secret);
+        let client_secret = std::env::var("FALCON_CLIENT_SECRET").ok().or_else(|| {
+            match read_secret_from_store(store, KEY_CLIENT_SECRET) {
+                StoreLookup::Found(v) => Some(v),
+                // Backend failures: do NOT fall back to plaintext toml.
+                // Surface the missing secret to the caller, which will turn
+                // into a "client_secret not set" error from validate().
+                StoreLookup::BackendError => None,
+                // Store skipped or empty: fall through to toml.
+                StoreLookup::SkipFallthrough | StoreLookup::NotStored => file.client_secret,
+            }
+        });
 
         let base_url = cli_base_url
             .map(String::from)
@@ -232,6 +331,12 @@ unsafe fn overwrite_environ_value(name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Resolve-related tests mutate process-global env vars (HOME,
+    /// XDG_CONFIG_HOME, FALCON_*) which makes them order-dependent under
+    /// cargo test's default thread-pool. Serialize them with a shared mutex.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_falcon_credentials_validate_ok() {
@@ -298,6 +403,7 @@ mod tests {
 
     #[test]
     fn test_falcon_credentials_resolve_cli_overrides_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_falcon_env() };
         unsafe {
             std::env::set_var("FALCON_CLIENT_ID", "env-id");
@@ -309,6 +415,7 @@ mod tests {
 
     #[test]
     fn test_falcon_credentials_resolve_env_fallback() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_falcon_env() };
         unsafe {
             std::env::set_var("FALCON_CLIENT_ID", "env-id");
@@ -322,6 +429,7 @@ mod tests {
 
     #[test]
     fn test_falcon_credentials_resolve_default_base_url() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_falcon_env() };
         let creds = FalconCredentials::resolve(None, None, None);
         assert_eq!(creds.base_url, "https://api.crowdstrike.com");
@@ -329,15 +437,20 @@ mod tests {
 
     #[test]
     fn test_falcon_credentials_resolve_empty() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe { clear_falcon_env() };
         let creds = FalconCredentials::resolve(None, None, None);
         assert!(creds.client_id.is_none());
-        assert!(creds.client_secret.is_none());
+        // client_secret may come from the host's Keychain when running on
+        // a developer machine that has a real entry. We only assert the
+        // other fields; resolve_with_store tests below use MemoryStore to
+        // pin the Keychain path deterministically.
         assert!(creds.member_cid.is_none());
     }
 
     #[test]
     fn test_falcon_credentials_clear_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("FALCON_CLIENT_ID", "test-id");
             std::env::set_var("FALCON_CLIENT_SECRET", "test-secret");
@@ -410,6 +523,7 @@ client_secret = "toml-secret"
 
     #[test]
     fn test_falcon_credentials_resolve_then_clear_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::set_var("FALCON_CLIENT_ID", "env-id");
             std::env::set_var("FALCON_CLIENT_SECRET", "env-secret");
@@ -430,5 +544,55 @@ client_secret = "toml-secret"
         // But env vars are gone.
         assert!(std::env::var("FALCON_CLIENT_ID").is_err());
         assert!(std::env::var("FALCON_CLIENT_SECRET").is_err());
+    }
+
+    #[test]
+    fn test_debug_masks_client_secret() {
+        let creds = FalconCredentials {
+            client_id: Some("id".into()),
+            client_secret: Some("super-secret".into()),
+            base_url: "https://example.com".to_string(),
+            member_cid: Some("cid".into()),
+        };
+        let dbg = format!("{:?}", creds);
+        assert!(
+            !dbg.contains("super-secret"),
+            "client_secret leaked: {}",
+            dbg
+        );
+        assert!(dbg.contains("***"));
+    }
+
+    #[test]
+    fn test_resolve_with_store_uses_keychain_when_no_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_falcon_env() };
+        let store = credential_store::test_support::MemoryStore::new();
+        store.set(KEY_CLIENT_SECRET, "kc-secret").unwrap();
+        let creds = FalconCredentials::resolve_with_store(None, None, None, Some(&store));
+        assert_eq!(creds.client_secret.as_deref(), Some("kc-secret"));
+    }
+
+    #[test]
+    fn test_resolve_with_store_env_overrides_keychain() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_falcon_env() };
+        unsafe { std::env::set_var("FALCON_CLIENT_SECRET", "env-secret") };
+        let store = credential_store::test_support::MemoryStore::new();
+        store.set(KEY_CLIENT_SECRET, "kc-secret").unwrap();
+        let creds = FalconCredentials::resolve_with_store(None, None, None, Some(&store));
+        assert_eq!(creds.client_secret.as_deref(), Some("env-secret"));
+        unsafe { std::env::remove_var("FALCON_CLIENT_SECRET") };
+    }
+
+    #[test]
+    fn test_resolve_with_store_falls_back_to_none_when_empty() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        unsafe { clear_falcon_env() };
+        let store = credential_store::test_support::MemoryStore::new();
+        // Both env and Keychain empty, and XDG_CONFIG_HOME=/nonexistent
+        // from clear_falcon_env prevents a user-level toml from being read.
+        let creds = FalconCredentials::resolve_with_store(None, None, None, Some(&store));
+        assert!(creds.client_secret.is_none());
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -239,5 +239,9 @@ pub async fn execute(client: &FalconClient, command: Command) -> error::Result<s
         Command::Profile { .. } => Err(crate::error::FalconError::Config(
             "profile command cannot be dispatched".to_string(),
         )),
+        // Credentials subcommand is handled in main.rs before dispatch.
+        Command::Credentials { .. } => Err(crate::error::FalconError::Config(
+            "credentials command cannot be dispatched".to_string(),
+        )),
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,9 @@ pub enum FalconError {
 
     #[error("configuration error: {0}")]
     Config(String),
+
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 }
 
 pub type Result<T> = std::result::Result<T, FalconError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -461,13 +461,13 @@ fn print_filtered_help(ap: &profile::ActiveProfile) {
         println!("  {}", line);
     }
 
-    // Always show agent, profile, completion.
+    // Always show agent, credentials, profile, completion.
     println!();
     println!("Agent:");
     println!("  agent");
     println!();
     println!("Configuration:");
-    println!("  profile");
+    println!("  credentials, profile");
 
     println!();
     println!(
@@ -698,13 +698,15 @@ fn handle_profile_command(action: &ProfileAction, cli_profile: Option<&str>) {
     }
 }
 
-/// Get the total number of API commands (excluding agent, profile, completion).
+/// Get the total number of API commands (excluding agent, profile,
+/// credentials, completion — these are operational commands, not
+/// CrowdStrike API endpoints).
 fn total_command_count() -> usize {
     let cmd = Cli::command();
     cmd.get_subcommands()
         .filter(|s| {
             let name = s.get_name();
-            name != "agent" && name != "profile" && name != "completion"
+            name != "agent" && name != "profile" && name != "credentials" && name != "completion"
         })
         .count()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,18 @@ fn main() {
         return;
     }
 
+    // Handle credentials store management early. We skip resolve() entirely
+    // because resolve() consults the OS credential store, which may prompt
+    // or fail with an ACL error — the whole point of `credentials status`
+    // is to tell the user about the store, not to be polluted by it.
+    if let Command::Credentials { ref action } = cli.command {
+        if let Err(e) = commands::credentials::handle(action) {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+        return;
+    }
+
     // Resolve credentials early (before fork).
     let credentials = FalconCredentials::resolve(
         cli.client_id.as_deref(),


### PR DESCRIPTION
## What this PR achieves

Replaces plaintext-only storage of the OAuth2 `client_secret` (env var or `credentials.toml`) with macOS Keychain-backed storage, eliminating Time Machine backup leakage, dotfile-repo commits, and same-uid malware reads as attack surface.

A new `falcon-cli credentials` subcommand handles `set` / `delete` / `status` / `migrate`. There is intentionally **no `get`**: the value never has to leave the Keychain for any legitimate workflow, and exposing one would invite leakage into shell history, terminal scrollback, and AI-agent transcripts.

## Why now

`credentials.toml` was the only place in the project where the long-lived OAuth2 `client_secret` was stored unprotected. `FALCON_*` env vars are already scrubbed from the process environment after `resolve()`, and the agent process intentionally does not propagate the secret to children. Leaving the toml as the sole persistent tier was the remaining gap.

This PR ports the design of [hiboma/mde-cli#52](https://github.com/hiboma/mde-cli/pull/52) and its hardening follow-up [hiboma/mde-cli#55](https://github.com/hiboma/mde-cli/pull/55) to `falcon-cli`. The mde-cli pair landed three independent review streams (security, compat, DX); this PR incorporates all of them up front instead of shipping the hardening as a separate change.

## How it is implemented

- **`src/config/credential_store.rs`** introduces a `CredentialStore` trait with a macOS `KeychainStore` (via the `keyring` crate, `apple-native` feature) and a test-only `MemoryStore` / `FailingStore`. The trait distinguishes `Unavailable` (no backend at all — non-macOS build, CI sandbox without a default keychain) from `Backend` (real access failure such as a denied prompt).
- **`FalconCredentials::resolve()`** consults the store between env vars and the toml. `Unavailable` falls through quietly; `Backend` does **not** fall through to the toml — silently picking up a stale plaintext value would defeat the migration. This invariant is exercised by `test_resolve_with_store_backend_error_does_not_fall_back_to_toml`.
- **`classify_keyring_err`** downcasts `keyring::Error::PlatformFailure` to `security_framework::base::Error` and classifies by OSStatus (`errSecNoDefaultKeychain` -25307, `errSecInvalidKeychain` -25295) instead of matching locale-translated strings, so Japanese macOS users are not misclassified.
- **`FalconCredentials`**'s `Debug` impl is hand-written to mask `client_secret` (`***`).
- Secrets held by `credentials set` / `credentials migrate` are wrapped in `zeroize::Zeroizing` so the heap allocation is wiped on drop; `atomic_replace` uses `tempfile::NamedTempFile::new_in` for a random tempfile name and auto-cleanup.
- `credentials migrate` writes to the Keychain first, then offers to remove the plaintext line via atomic temp-file rename (default) or keep a 0o600 backup (opt-in, with a loud warning). A rewrite failure rolls the Keychain entry back.
- `status` points users at the README's Keychain ACL section when an entry returns an access error (typical after a `cargo install` rebuild changes the binary's code signature).
- `main.rs` routes `credentials` / `completion` before `resolve()` so the subcommand does not itself trigger a Keychain prompt.

Full decision record: `docs/adr/0005-keychain-backed-client-secret.md`.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings` (project's documented check)
- [x] `cargo test --bin falcon-cli` — 71 passed (26 new), 0 failed
- [x] `cargo test --bin falcon-cli -- --test-threads=1` — 71 passed (verifies `ENV_LOCK` serializes env-mutating tests)
- [x] `cargo deny check bans licenses sources` — pass (`advisories` has a pre-existing `rustls-webpki` finding, unrelated to this PR)
- [x] Manual smoke: `credentials set client-secret --stdin` → `status` (stored) → `delete client-secret` → `status` (not stored) roundtrip against the real login keychain
- [ ] Manual smoke: `credentials migrate` against a real `credentials.toml`

## Notes for review

- macOS Keychain prompts the user on first access. Users who pin the entry with "Always Allow" see no further prompts unless the binary's signature changes (e.g. after a `cargo install` rebuild). README documents this.
- `security-framework` is explicitly pinned to major `3` so the `downcast_ref::<security_framework::base::Error>()` in `classify_keyring_err` sees the same type `keyring`'s apple-native backend is producing. If `keyring` upgrades that pin in a future release, this crate must follow in lockstep or the downcast silently falls through to the string-match fallback.
- Linux / Windows backends are intentionally out of scope; the trait makes them straightforward to add.
- `tests/cli_test.rs::test_missing_credentials_error` fails on hosts that have a `credentials.toml` in `~/.config/falcon-cli/` — pre-existing on `main`, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)