### PR TITLE
docs: link ADR-0005 from README and document the no-Keychain-in-child invariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ CLI options (`--client-id`, `--base-url`, `--member-cid`) override environment v
 
 ### Credential storage (macOS Keychain)
 
+See [ADR-0005: Keychain による client_secret の保管](docs/adr/0005-keychain-backed-client-secret.md) for the full design rationale, including the `StoreError::{Unavailable, Backend}` fallthrough policy and the OSStatus-based `classify_keyring_err` decision.
+
 `falcon-cli` resolves the OAuth2 `client_secret` from the following sources, highest priority first:
 
 1. `FALCON_CLIENT_SECRET` environment variable

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -31,6 +31,17 @@ fn check_already_running() -> Option<u32> {
 ///
 /// The agent always uses `session.json` for cross-terminal auto-detection.
 /// Use `--foreground` to run without forking.
+///
+/// INVARIANT: the `credentials` argument is a fully resolved
+/// `FalconCredentials` struct. The parent process has already consulted
+/// the OS credential store (macOS Keychain) if necessary; the forked
+/// child MUST NOT touch the store again. Every child-side code path
+/// that needs `client_secret` reads it from this in-memory struct (via
+/// `self.config.client_secret` in `Auth::refresh_token`). Re-reading
+/// the Keychain from the child would: (1) re-trigger an ACL prompt in a
+/// context with no TTY (silent failure), (2) widen the set of binaries
+/// whose code signature the user must trust, and (3) break the
+/// single-resolve guarantee documented in ADR-0005.
 pub fn start(
     falcon_client: Arc<crate::client::FalconClient>,
     socket_path: &Path,


### PR DESCRIPTION
## Summary

Two doc-only follow-ups from #66:

- **#74**: README's "Credential storage (macOS Keychain)" section now links ADR-0005 up front, so readers can find the design rationale (\`StoreError\` fallthrough policy, OSStatus classification) without hunting for it.
- **#75**: \`agent::server::start\` gains a doc comment documenting the invariant that the forked agent child must not consult the OS credential store. The property already holds in the current codebase (agent has no references to \`KeychainStore\` or \`default_store\`), but making it explicit prevents a future refactor from silently re-introducing Keychain access on the child side — which would trigger ACL prompts in a TTY-less context and break the single-resolve guarantee from ADR-0005.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -- -D warnings\`
- [x] \`cargo test\` (no behavior change, doc-only)

Closes #74, closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)