### PR TITLE
test(cli): isolate test_missing_credentials_error from host state

### DIFF
--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -213,15 +213,44 @@ fn test_alert_update_help() {
 
 #[test]
 fn test_missing_credentials_error() {
-    let output = Command::new("cargo")
-        .args(["run", "--", "--no-agent", "host", "list"])
+    // Isolate the subprocess from the developer's real setup: a populated
+    // `~/.config/falcon-cli/credentials.toml`, a live agent `session.json`,
+    // or a `.falcon-credentials.toml` in the repo root would all let
+    // `resolve()` find a secret and defeat the "missing credentials"
+    // assertion.
+    //
+    //   - HOME              -> tempdir so `~/.config/falcon-cli/credentials.toml`
+    //                          is unreachable
+    //   - XDG_CONFIG_HOME   -> tempdir for the same reason
+    //   - current_dir       -> tempdir so `.falcon-credentials.toml` cannot be
+    //                          picked up
+    //   - FALCON_AGENT_SOCKET cleared alongside FALCON_AGENT_TOKEN
+    //
+    // We invoke the already-built test binary directly via
+    // `CARGO_BIN_EXE_<name>` (auto-populated by cargo for integration tests)
+    // rather than `cargo run`, so `current_dir` can be an arbitrary tempdir
+    // without cargo complaining about a missing Cargo.toml.
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let cwd = tempfile::tempdir().expect("create cwd tempdir");
+    let bin = env!("CARGO_BIN_EXE_falcon-cli");
+
+    let output = Command::new(bin)
+        .args(["--no-agent", "host", "list"])
+        .current_dir(cwd.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path())
         .env_remove("FALCON_CLIENT_ID")
         .env_remove("FALCON_CLIENT_SECRET")
         .env_remove("FALCON_AGENT_TOKEN")
+        .env_remove("FALCON_AGENT_SOCKET")
         .output()
         .expect("failed to execute");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("FALCON_CLIENT_ID"));
+    assert!(
+        stderr.contains("FALCON_CLIENT_ID"),
+        "expected stderr to mention FALCON_CLIENT_ID, got: {}",
+        stderr
+    );
     assert!(!output.status.success());
 }


### PR DESCRIPTION
## Summary

\`test_missing_credentials_error\` asserts that running \`falcon-cli --no-agent host list\` without \`FALCON_*\` env vars produces a "FALCON_CLIENT_ID" error, but it would fail on any developer host that has at least one of:

- \`~/.config/falcon-cli/credentials.toml\` with a real \`client_secret\`
- \`.falcon-credentials.toml\` in the repo root (cwd during \`cargo test\`)
- a live agent \`session.json\` (\`FALCON_AGENT_SOCKET\` inherited via env)

…because \`FalconCredentials::resolve()\` would pick up a secret through one of those channels and the CLI would proceed to make an HTTP call instead of erroring out.

## What changed

- Redirect \`HOME\` and \`XDG_CONFIG_HOME\` at fresh tempdirs so both toml search paths miss.
- Run with \`current_dir\` at a separate tempdir so a stray repo-root \`.falcon-credentials.toml\` cannot be picked up.
- \`env_remove\` \`FALCON_AGENT_SOCKET\` alongside \`FALCON_AGENT_TOKEN\`.
- Invoke the test binary directly via \`CARGO_BIN_EXE_falcon-cli\` so cargo does not need to resolve a \`Cargo.toml\` inside the tempdir.

## Known limitation

The Keychain path is not isolated. On macOS with a real \`dev.falcon-cli\` entry, this test still lets the subprocess resolve the secret from the Keychain and the assertion fails. Developers who have migrated to the Keychain can \`falcon-cli credentials delete client-secret\` before running this test, or skip it. Making the test fully platform-independent (e.g. by injecting a fake store or by gating on \`target_os\`) is a separate concern and not blocking.

## Test plan

- [x] \`cargo test\` locally (9 integration + 71 unit tests pass)
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -- -D warnings\`
- [x] Reproduced the original failure (test fails on a host with \`~/.config/falcon-cli/credentials.toml\` populated) before the fix, and confirmed it passes after.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)