### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary

Minor bump (0.9.1 → 0.10.0) for the Keychain-backed credential storage feature landed since the last release.

## Changes since v0.9.1

- **feat(credentials)**: back \`client_secret\` with macOS Keychain (#66). New \`falcon-cli credentials {set,delete,status,migrate}\` subcommand. Resolve order for \`client_secret\`: env > Keychain > toml. Includes \`Debug\` masking, \`Zeroizing\`, \`tempfile\` atomic_replace, OSStatus-based keyring error classification. See [ADR-0005](docs/adr/0005-keychain-backed-client-secret.md).
- **docs**: link ADR-0005 from README and document the no-Keychain-in-child invariant on the agent fork path (#77).
- **test(cli)**: isolate \`test_missing_credentials_error\` from host state (#78).
- **ci**: add cargo-deny supply-chain checks (#58, merged earlier).

## Why 0.10.0 rather than 0.9.2

Per SemVer on 0.x, minor bumps signal new user-visible functionality (the \`credentials\` subcommand is new), while patches are reserved for fixes. Users who already have a working \`credentials.toml\` setup continue to work without any action; migration to the Keychain is opt-in via \`falcon-cli credentials migrate\`.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo test\` — 71 unit + 9 integration pass
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -- -D warnings\`
- [x] \`cargo deny check\` (advisories / bans / licenses / sources)

After this PR merges, a \`v0.10.0\` tag push will trigger \`.github/workflows/release.yml\` to build and publish the release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)