### PR TITLE
ci: disable persist-credentials on actions/checkout to shrink token leak surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt, clippy
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
         with:
           command: check
@@ -53,6 +57,8 @@ jobs:
             os: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
             os: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Motivation

Harden the GitHub Actions surface so that a compromised step or
script-injection payload cannot exfiltrate `GITHUB_TOKEN` from the
runner's git config file.

## Why

By default, `actions/checkout` writes the workflow `GITHUB_TOKEN` into
`.git/config` (as `http.extraheader`) and persists it for the rest of
the job. Any subsequent step — including a third-party action or a
malicious string injected through workflow inputs — can read that
file and obtain a short-lived but powerful repository token. This is
the primary mechanism behind several recent supply-chain incidents
against `tj-actions/changed-files` and similar.

In this repository, none of the jobs in `ci.yml` or `release.yml`
perform authenticated git operations after checkout. They only run
cargo (build, fmt, clippy, test, deny), `cross`, `tar`, and
`upload-artifact`. The release publish step uses
`softprops/action-gh-release`, which consumes `GITHUB_TOKEN` directly
from the environment rather than from `.git/config`. The persisted
credential is therefore unused — but it still expands the blast
radius if any step is compromised.

`scorecard.yml` already opts out. This PR brings the four remaining
`actions/checkout` invocations in line.

Reference: https://zenn.dev/kou_pg_0131/articles/gha-checkout-persist-credentials

## How

Added `with: persist-credentials: false` to every `actions/checkout`
step in `ci.yml` (check / deny / build jobs) and `release.yml` (build
job). The `release` job in `release.yml` does not check out the
repository, so no change is required there.

Verified with parallel subagent review:
- No submodules, no Git LFS, no private git dependencies in
  `Cargo.toml` / `Cargo.lock`, so disabling credential persistence
  does not break any fetch.
- All third-party actions remain pinned to 40-char SHAs.
- `permissions:` blocks are already minimized.

[comment by CC]