### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Summary

Patch bump (0.10.0 → 0.10.1) for dependency maintenance. No user-visible feature or API change; this release rolls up the dependency and CI updates merged since v0.10.0.

## Changes since v0.10.0

- chore(deps): bump rand 0.9.2 → 0.9.4 (#63)
- chore(deps): bump clap_complete 4.6.0 → 4.6.2 (#80)
- chore(deps): bump clap 4.6.0 → 4.6.1 (#81)
- chore(deps): bump uuid 1.23.0 → 1.23.1 (#82)
- chore(deps): bump tokio 1.51.0 → 1.52.1 (#83)
- chore(deps): bump actions/checkout 6.0.2 → 6.0.3 (#94)
- chore(deps): bump github/codeql-action 4.35.1 → 4.36.2 (#93)
- chore(deps): bump EmbarkStudios/cargo-deny-action 2.0.16 → 2.0.20 (#92)
- chore(deps): bump actions/upload-artifact 7.0.0 → 7.0.1 (#60)
- chore(deps): bump softprops/action-gh-release 2.6.1 → 3.0.0 (#59)
- ci: set persist-credentials: false on actions/checkout (#91)

## Note

rpassword 7.5.0 (#85) was intentionally **not** adopted: it fails to compile on macOS (references `libc::__errno_location`, a Linux-only symbol). It is ignored until a macOS-compatible release.

## Verification

- `cargo build` succeeds (falcon-cli v0.10.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)