### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## 概要

doctor サブコマンド追加に対する minor bump（0.10.1 → 0.11.0）です。

## v0.10.1 以降の変更

- feat: add doctor subcommand for diagnosing config and connectivity (#103)

`falcon-cli doctor` は CONFIG / RESOLVED CREDENTIALS / ACTIVE PROFILE / ENVIRONMENT / CONNECTIVITY を報告します（`jamf-cli doctor` を参考）。シークレット値は一切出力しません。

## リリース手順

このPRをマージ後、main に `v0.11.0` タグを push してリリースワークフローをトリガーします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)