### PR TITLE
feat: add ngsiem search subcommand for CQL queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +278,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +352,7 @@ dependencies = [
  "tokio",
  "toml",
  "uuid",
+ "wiremock",
  "zeroize",
 ]
 
@@ -338,6 +367,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -355,12 +390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -368,6 +419,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -381,8 +466,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -434,6 +524,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +562,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -494,6 +609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,9 +624,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -758,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +983,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1485,6 +1624,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2182,29 @@ name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ rpassword = "7"
 tempfile = "3"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
+[dev-dependencies]
+wiremock = "0.6"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"
 security-framework-sys = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/hiboma/falcon-cli"
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ falcon-cli ngsiem search --query '#event_simpleName=ProcessRollup2 | tail(10)' -
 | `fdr` | Manage FDR |
 | `firewall` | Manage firewall rules |
 | `logscale` | Manage Foundry LogScale |
-| `ngsiem` | Manage NGSIEM |
+| `ngsiem` | Manage NGSIEM rules and run CQL event searches |
 | `sample` | Manage sample uploads |
 | `saas-security` | Manage SaaS security |
 | `faas` | Manage FaaS executions |

--- a/README.md
+++ b/README.md
@@ -563,6 +563,10 @@ falcon-cli api-integration list --limit 10
 
 # Get delivery settings
 falcon-cli delivery-setting get
+
+# Run a CQL search against NG-SIEM (same as Investigate > Advanced event search)
+# Requires the NGSIEM: READ/WRITE API scopes
+falcon-cli ngsiem search --query '#event_simpleName=ProcessRollup2 | tail(10)' --start 1h
 ```
 
 | Command | Description |

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,7 +116,6 @@ impl FalconClient {
     }
 
     /// Send a DELETE request with automatic re-authentication on 401.
-    #[allow(dead_code)]
     pub async fn delete(&self, path: &str) -> Result<serde_json::Value> {
         let url = format!("{}{}", self.base_url, path);
         let token = self.auth.get_token().await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -175,7 +175,7 @@ impl FalconClient {
 
     /// Truncate on a char boundary; `String::truncate` panics on
     /// multibyte boundaries, which API error bodies can contain.
-    fn truncate_chars(s: &str, max: usize) -> String {
+    pub(crate) fn truncate_chars(s: &str, max: usize) -> String {
         s.chars().take(max).collect()
     }
 
@@ -230,5 +230,73 @@ mod tests {
         assert!(!FalconClient::is_loopback_http("https://localhost"));
         assert!(!FalconClient::is_loopback_http("ftp://localhost"));
         assert!(!FalconClient::is_loopback_http(""));
+    }
+
+    #[tokio::test]
+    async fn test_delete_accepts_empty_204_body() {
+        let server = wiremock::MockServer::start().await;
+        let client = test_support::mock_client(&server).await;
+
+        wiremock::Mock::given(wiremock::matchers::method("DELETE"))
+            .and(wiremock::matchers::path("/some/resource"))
+            .respond_with(wiremock::ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let value = client
+            .delete("/some/resource")
+            .await
+            .expect("204 is success");
+        assert_eq!(value, serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn test_error_body_is_truncated_on_char_boundary() {
+        let server = wiremock::MockServer::start().await;
+        let client = test_support::mock_client(&server).await;
+
+        // 300 3-byte chars: a byte-based truncate(200) would panic here.
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/fails"))
+            .respond_with(wiremock::ResponseTemplate::new(500).set_body_string("あ".repeat(300)))
+            .mount(&server)
+            .await;
+
+        let err = client.get("/fails").await.expect_err("500 is an error");
+        let msg = err.to_string();
+        assert!(msg.contains("500"));
+        assert!(msg.chars().filter(|c| *c == 'あ').count() == 200);
+    }
+}
+
+/// Shared helpers for wiremock-backed tests in this crate.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::FalconClient;
+    use crate::auth::Auth;
+    use crate::config::Config;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Build a `FalconClient` against a wiremock server with the OAuth2
+    /// token endpoint stubbed out.
+    pub(crate) async fn mock_client(server: &MockServer) -> FalconClient {
+        Mock::given(method("POST"))
+            .and(path("/oauth2/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "test-token",
+                "expires_in": 1799,
+            })))
+            .mount(server)
+            .await;
+
+        let config = Config {
+            client_id: "test-client-id".to_string(),
+            client_secret: "test-client-secret".to_string(),
+            base_url: server.uri(),
+            member_cid: None,
+        };
+        FalconClient::new(Auth::new(config), server.uri()).expect("loopback http client")
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -141,9 +141,16 @@ impl FalconClient {
         let body = resp.text().await?;
 
         if !status.is_success() {
-            let mut truncated = body.clone();
-            truncated.truncate(200);
-            return Err(FalconError::Api(format!("{}: {}", status, truncated)));
+            return Err(FalconError::Api(format!(
+                "{}: {}",
+                status,
+                Self::truncate_chars(&body, 200)
+            )));
+        }
+
+        // 204 No Content and other empty success bodies are not JSON.
+        if body.is_empty() {
+            return Ok(serde_json::Value::Null);
         }
 
         let value: serde_json::Value = serde_json::from_str(&body)?;
@@ -155,13 +162,21 @@ impl FalconClient {
 
         if !status.is_success() {
             let body = resp.text().await?;
-            let mut truncated = body;
-            truncated.truncate(200);
-            return Err(FalconError::Api(format!("{}: {}", status, truncated)));
+            return Err(FalconError::Api(format!(
+                "{}: {}",
+                status,
+                Self::truncate_chars(&body, 200)
+            )));
         }
 
         let bytes = resp.bytes().await?;
         Ok(bytes.to_vec())
+    }
+
+    /// Truncate on a char boundary; `String::truncate` panics on
+    /// multibyte boundaries, which API error bodies can contain.
+    fn truncate_chars(s: &str, max: usize) -> String {
+        s.chars().take(max).collect()
     }
 
     fn is_loopback_http(url: &str) -> bool {
@@ -198,6 +213,15 @@ mod tests {
     fn test_is_loopback_http_rejects_subdomain_bypass() {
         assert!(!FalconClient::is_loopback_http("http://localhost.evil.com"));
         assert!(!FalconClient::is_loopback_http("http://127.0.0.1.evil.com"));
+    }
+
+    #[test]
+    fn test_truncate_chars_multibyte_boundary() {
+        // 100 3-byte chars: byte 200 is not a char boundary.
+        let s = "あ".repeat(100);
+        let t = FalconClient::truncate_chars(&s, 200);
+        assert_eq!(t.chars().count(), 100);
+        assert!(FalconClient::truncate_chars(&s, 50).chars().count() == 50);
     }
 
     #[test]

--- a/src/commands/ngsiem.rs
+++ b/src/commands/ngsiem.rs
@@ -8,6 +8,9 @@ use crate::commands::{build_query_path, encode};
 use crate::error::{FalconError, Result};
 
 const SEARCH_POLL_INTERVAL: Duration = Duration::from_secs(1);
+/// The poll interval doubles after every poll up to this cap, so long
+/// `--timeout` values do not hammer the API.
+const SEARCH_POLL_MAX_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -124,35 +127,53 @@ async fn search(
     );
     let job = client.post(&jobs_path, &body).await?;
     let id = job["id"].as_str().ok_or_else(|| {
-        let truncated: String = job.to_string().chars().take(200).collect();
-        FalconError::Api(format!("queryjob id missing in response: {}", truncated))
+        FalconError::Api(format!(
+            "queryjob id missing in response: {}",
+            FalconClient::truncate_chars(&job.to_string(), 200)
+        ))
     })?;
     let job_path = format!("{}/{}", jobs_path, encode(id));
 
+    let outcome = tokio::select! {
+        res = poll_until_done(client, &job_path, id, timeout) => res,
+        // Ctrl-C: fall through to the cleanup below instead of leaving
+        // the query job running server-side.
+        _ = tokio::signal::ctrl_c() => Err(FalconError::Api(format!(
+            "search interrupted (job id: {})",
+            id
+        ))),
+    };
+
+    // Free server-side resources in every outcome; on success the result
+    // is already in hand. A failed cleanup is not worth surfacing.
+    let _ = client.delete(&job_path).await;
+
+    outcome
+}
+
+/// Poll a query job until `done: true`, a poll fails, or `timeout` elapses.
+async fn poll_until_done(
+    client: &FalconClient,
+    job_path: &str,
+    id: &str,
+    timeout: u64,
+) -> Result<serde_json::Value> {
     let started = Instant::now();
     let limit = Duration::from_secs(timeout);
+    let mut interval = SEARCH_POLL_INTERVAL;
     loop {
-        let result = match client.get(&job_path).await {
-            Ok(result) => result,
-            Err(e) => {
-                // Do not leave the job running server-side.
-                let _ = client.delete(&job_path).await;
-                return Err(e);
-            }
-        };
+        let result = client.get(job_path).await?;
         if result["done"].as_bool().unwrap_or(false) {
-            // Free server-side resources; the result is already in hand.
-            let _ = client.delete(&job_path).await;
             return Ok(result);
         }
         if started.elapsed() >= limit {
-            let _ = client.delete(&job_path).await;
             return Err(FalconError::Api(format!(
                 "search did not complete within {}s (job id: {})",
                 timeout, id
             )));
         }
-        tokio::time::sleep(SEARCH_POLL_INTERVAL).await;
+        tokio::time::sleep(interval).await;
+        interval = (interval * 2).min(SEARCH_POLL_MAX_INTERVAL);
     }
 }
 
@@ -171,5 +192,163 @@ mod tests {
         assert!(validate_repository("").is_err());
         assert!(validate_repository(".").is_err());
         assert!(validate_repository("..").is_err());
+    }
+
+    mod search_lifecycle {
+        use super::super::search;
+        use crate::client::test_support::mock_client;
+        use serde_json::json;
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        const JOBS_PATH: &str = "/humio/api/v1/repositories/search-all/queryjobs";
+        const JOB_PATH: &str = "/humio/api/v1/repositories/search-all/queryjobs/job-1";
+
+        async fn mount_job_created(server: &MockServer) {
+            Mock::given(method("POST"))
+                .and(path(JOBS_PATH))
+                .and(body_partial_json(json!({"isLive": false})))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id": "job-1"})))
+                .expect(1)
+                .mount(server)
+                .await;
+        }
+
+        async fn mount_job_deleted(server: &MockServer) {
+            Mock::given(method("DELETE"))
+                .and(path(JOB_PATH))
+                .respond_with(ResponseTemplate::new(204))
+                .expect(1)
+                .mount(server)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn polls_until_done_and_deletes_the_job() {
+            let server = MockServer::start().await;
+            let client = mock_client(&server).await;
+            mount_job_created(&server).await;
+            mount_job_deleted(&server).await;
+
+            // The first poll is still running; it is mounted first and
+            // limited to one match so the retry falls through to "done".
+            Mock::given(method("GET"))
+                .and(path(JOB_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"done": false})))
+                .up_to_n_times(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path(JOB_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "done": true,
+                    "events": [{"#event_simpleName": "ProcessRollup2"}],
+                })))
+                .mount(&server)
+                .await;
+
+            let result = search(
+                &client,
+                "#event_simpleName=Foo",
+                "search-all",
+                "1h",
+                None,
+                60,
+            )
+            .await
+            .expect("search completes");
+            assert_eq!(result["done"], json!(true));
+            assert_eq!(result["events"].as_array().map(Vec::len), Some(1));
+        }
+
+        #[tokio::test]
+        async fn deletes_the_job_when_a_poll_fails() {
+            let server = MockServer::start().await;
+            let client = mock_client(&server).await;
+            mount_job_created(&server).await;
+            mount_job_deleted(&server).await;
+
+            Mock::given(method("GET"))
+                .and(path(JOB_PATH))
+                .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let err = search(&client, "q", "search-all", "1h", None, 60)
+                .await
+                .expect_err("poll failure propagates");
+            assert!(err.to_string().contains("500"));
+        }
+
+        #[tokio::test]
+        async fn deletes_the_job_on_timeout() {
+            let server = MockServer::start().await;
+            let client = mock_client(&server).await;
+            mount_job_created(&server).await;
+            mount_job_deleted(&server).await;
+
+            // --timeout 0: a single not-done poll trips the deadline
+            // without sleeping, keeping the test fast.
+            Mock::given(method("GET"))
+                .and(path(JOB_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"done": false})))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let err = search(&client, "q", "search-all", "1h", None, 0)
+                .await
+                .expect_err("timeout is an error");
+            let msg = err.to_string();
+            assert!(msg.contains("did not complete within 0s"));
+            assert!(msg.contains("job-1"));
+        }
+
+        #[tokio::test]
+        async fn reports_a_missing_job_id() {
+            let server = MockServer::start().await;
+            let client = mock_client(&server).await;
+
+            Mock::given(method("POST"))
+                .and(path(JOBS_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let err = search(&client, "q", "search-all", "1h", None, 60)
+                .await
+                .expect_err("missing id is an error");
+            assert!(err.to_string().contains("queryjob id missing"));
+        }
+
+        #[tokio::test]
+        async fn passes_the_end_bound_through() {
+            let server = MockServer::start().await;
+            let client = mock_client(&server).await;
+            mount_job_deleted(&server).await;
+
+            Mock::given(method("POST"))
+                .and(path(JOBS_PATH))
+                .and(body_partial_json(json!({
+                    "queryString": "q",
+                    "start": "2h",
+                    "end": "1h",
+                })))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id": "job-1"})))
+                .expect(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path(JOB_PATH))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"done": true})))
+                .mount(&server)
+                .await;
+
+            search(&client, "q", "search-all", "2h", Some("1h"), 60)
+                .await
+                .expect("search completes");
+        }
     }
 }

--- a/src/commands/ngsiem.rs
+++ b/src/commands/ngsiem.rs
@@ -1,8 +1,13 @@
+use std::time::{Duration, Instant};
+
 use clap::Subcommand;
+use serde_json::json;
 
 use crate::client::FalconClient;
-use crate::commands::build_query_path;
-use crate::error::Result;
+use crate::commands::{build_query_path, encode};
+use crate::error::{FalconError, Result};
+
+const SEARCH_POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -26,6 +31,28 @@ pub enum Action {
         #[arg(long, required = true, num_args = 1..)]
         id: Vec<String>,
     },
+    /// Run a CQL search (Advanced event search) and wait for results
+    Search {
+        /// CQL query string
+        #[arg(long)]
+        query: String,
+
+        /// Repository or view to search
+        #[arg(long, default_value = "search-all")]
+        repository: String,
+
+        /// Start of the time range (relative like "1h", "7d", or epoch millis)
+        #[arg(long, default_value = "1h")]
+        start: String,
+
+        /// End of the time range (relative or epoch millis; defaults to now)
+        #[arg(long)]
+        end: Option<String>,
+
+        /// Seconds to wait for the search to complete
+        #[arg(long, default_value = "60")]
+        timeout: u64,
+    },
 }
 
 pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json::Value> {
@@ -48,5 +75,59 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
             let path = format!("/ngsiem/entities/rules/v1?{}", ids.join("&"));
             client.get(&path).await
         }
+        Action::Search {
+            query,
+            repository,
+            start,
+            end,
+            timeout,
+        } => search(client, &query, &repository, &start, end.as_deref(), timeout).await,
+    }
+}
+
+/// Start a query job, poll until it completes, and return the final result.
+async fn search(
+    client: &FalconClient,
+    query: &str,
+    repository: &str,
+    start: &str,
+    end: Option<&str>,
+    timeout: u64,
+) -> Result<serde_json::Value> {
+    let mut body = json!({
+        "queryString": query,
+        "start": start,
+        "isLive": false,
+    });
+    if let Some(end) = end {
+        body["end"] = json!(end);
+    }
+
+    let jobs_path = format!(
+        "/humio/api/v1/repositories/{}/queryjobs",
+        encode(repository)
+    );
+    let job = client.post(&jobs_path, &body).await?;
+    let id = job["id"]
+        .as_str()
+        .ok_or_else(|| FalconError::Api(format!("queryjob id missing in response: {}", job)))?;
+    let job_path = format!("{}/{}", jobs_path, encode(id));
+
+    let deadline = Instant::now() + Duration::from_secs(timeout);
+    loop {
+        let result = client.get(&job_path).await?;
+        if result["done"].as_bool().unwrap_or(false) {
+            // Free server-side resources; the result is already in hand.
+            let _ = client.delete(&job_path).await;
+            return Ok(result);
+        }
+        if Instant::now() >= deadline {
+            let _ = client.delete(&job_path).await;
+            return Err(FalconError::Api(format!(
+                "search did not complete within {}s (job id: {})",
+                timeout, id
+            )));
+        }
+        tokio::time::sleep(SEARCH_POLL_INTERVAL).await;
     }
 }

--- a/src/commands/ngsiem.rs
+++ b/src/commands/ngsiem.rs
@@ -7,7 +7,7 @@ use crate::client::FalconClient;
 use crate::commands::{build_query_path, encode};
 use crate::error::{FalconError, Result};
 
-const SEARCH_POLL_INTERVAL: Duration = Duration::from_millis(1000);
+const SEARCH_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -85,6 +85,19 @@ pub async fn execute(client: &FalconClient, action: Action) -> Result<serde_json
     }
 }
 
+/// Reject repository names that would escape the intended URL path.
+/// `.` and `..` survive percent-encoding as-is and are collapsed as
+/// dot segments when the URL is parsed.
+fn validate_repository(repository: &str) -> Result<()> {
+    if repository.is_empty() || repository == "." || repository == ".." {
+        return Err(FalconError::InvalidInput(format!(
+            "invalid repository name: {:?}",
+            repository
+        )));
+    }
+    Ok(())
+}
+
 /// Start a query job, poll until it completes, and return the final result.
 async fn search(
     client: &FalconClient,
@@ -94,6 +107,8 @@ async fn search(
     end: Option<&str>,
     timeout: u64,
 ) -> Result<serde_json::Value> {
+    validate_repository(repository)?;
+
     let mut body = json!({
         "queryString": query,
         "start": start,
@@ -108,20 +123,29 @@ async fn search(
         encode(repository)
     );
     let job = client.post(&jobs_path, &body).await?;
-    let id = job["id"]
-        .as_str()
-        .ok_or_else(|| FalconError::Api(format!("queryjob id missing in response: {}", job)))?;
+    let id = job["id"].as_str().ok_or_else(|| {
+        let truncated: String = job.to_string().chars().take(200).collect();
+        FalconError::Api(format!("queryjob id missing in response: {}", truncated))
+    })?;
     let job_path = format!("{}/{}", jobs_path, encode(id));
 
-    let deadline = Instant::now() + Duration::from_secs(timeout);
+    let started = Instant::now();
+    let limit = Duration::from_secs(timeout);
     loop {
-        let result = client.get(&job_path).await?;
+        let result = match client.get(&job_path).await {
+            Ok(result) => result,
+            Err(e) => {
+                // Do not leave the job running server-side.
+                let _ = client.delete(&job_path).await;
+                return Err(e);
+            }
+        };
         if result["done"].as_bool().unwrap_or(false) {
             // Free server-side resources; the result is already in hand.
             let _ = client.delete(&job_path).await;
             return Ok(result);
         }
-        if Instant::now() >= deadline {
+        if started.elapsed() >= limit {
             let _ = client.delete(&job_path).await;
             return Err(FalconError::Api(format!(
                 "search did not complete within {}s (job id: {})",
@@ -129,5 +153,23 @@ async fn search(
             )));
         }
         tokio::time::sleep(SEARCH_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_repository_accepts_normal_names() {
+        assert!(validate_repository("search-all").is_ok());
+        assert!(validate_repository("my.repo").is_ok());
+    }
+
+    #[test]
+    fn test_validate_repository_rejects_dot_segments() {
+        assert!(validate_repository("").is_err());
+        assert!(validate_repository(".").is_err());
+        assert!(validate_repository("..").is_err());
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -212,6 +212,35 @@ fn test_alert_update_help() {
 }
 
 #[test]
+fn test_ngsiem_help() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "ngsiem", "--help"])
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("list"));
+    assert!(stdout.contains("get"));
+    assert!(stdout.contains("search"));
+}
+
+#[test]
+fn test_ngsiem_search_help() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "ngsiem", "search", "--help"])
+        .output()
+        .expect("failed to execute");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("--query"));
+    assert!(stdout.contains("--repository"));
+    assert!(stdout.contains("--start"));
+    assert!(stdout.contains("--end"));
+    assert!(stdout.contains("--timeout"));
+    assert!(stdout.contains("search-all"));
+}
+
+#[test]
 fn test_missing_credentials_error() {
     // Isolate the subprocess from the developer's real setup: a populated
     // `~/.config/falcon-cli/credentials.toml`, a live agent `session.json`,


### PR DESCRIPTION
## Motivation

Bring Investigate > Advanced event search to the CLI. falcon-cli could manage NG-SIEM rules but had no way to run event searches, so investigations still required the Falcon console. With this change, CQL queries can be scripted and piped like every other falcon-cli command.

## Why

The Advanced event search UI is backed by the NG-SIEM query jobs API (`/humio/api/v1/repositories/{repository}/queryjobs`), which is a public, OAuth2-scoped endpoint. Since falcon-cli already handles token acquisition and JSON output, wrapping the job lifecycle (start, poll, cleanup) is a natural fit for the existing `ngsiem` command.

## How

```bash
falcon-cli ngsiem search --query '#event_simpleName=ProcessRollup2 | tail(10)' --start 1h
```

- `ngsiem search` POSTs a query job, polls every second until `done: true` or `--timeout` (default 60s), and DELETEs the job afterwards (also on poll failure and timeout) to free server-side resources
- Defaults to the `search-all` view; `--repository` overrides it, with validation that rejects dot-segment names
- Requires the `NGSIEM: READ/WRITE` API scopes

Also hardens `FalconClient` response handling found during review: UTF-8-safe truncation of error bodies and empty 204 bodies treated as success.

## Notes

Verified with a smoke test against a live tenant (NGSIEM scopes). Review follow-ups are included: Ctrl-C now cleans up the server-side query job, polling backs off exponentially (1s doubling up to 5s), and the search job lifecycle is covered by wiremock-based tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
