### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "falcon-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "falcon-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 description = "A CLI tool for CrowdStrike Falcon API"


### PR DESCRIPTION
## Motivation

Release v0.12.0 with the `ngsiem search` subcommand (#107), which runs CQL queries against NG-SIEM (Advanced event search) from the CLI.

## Changes

- Cargo.toml / Cargo.lock: 0.11.0 -> 0.12.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)